### PR TITLE
Remove all panics in HLL implementation, replaced with error returns

### DIFF
--- a/common/family.go
+++ b/common/family.go
@@ -18,5 +18,5 @@
 package common
 
 const (
-	Family_HLL_ID = 7
+	FamilyHllId = 7
 )

--- a/common/utils.go
+++ b/common/utils.go
@@ -18,17 +18,18 @@
 package common
 
 import (
+	"fmt"
 	"math"
 	"math/bits"
 	"strconv"
 )
 
 // InvPow2 returns 2^(-e).
-func InvPow2(e int) float64 {
+func InvPow2(e int) (float64, error) {
 	if (e | 1024 - e - 1) < 0 {
-		panic("e cannot be negative or greater than 1023: " + strconv.Itoa(e))
+		return 0, fmt.Errorf("e cannot be negative or greater than 1023: " + strconv.Itoa(e))
 	}
-	return math.Float64frombits((1023 - uint64(e)) << 52)
+	return math.Float64frombits((1023 - uint64(e)) << 52), nil
 }
 
 // CeilPowerOf2 returns the smallest power of 2 greater than or equal to n.
@@ -43,11 +44,11 @@ func CeilPowerOf2(n int) int {
 	return int(math.Pow(2, math.Ceil(math.Log2(float64(n)))))
 }
 
-func ExactLog2OfLong(powerOf2 uint64) int {
+func ExactLog2OfLong(powerOf2 uint64) (int, error) {
 	if !isLongPowerOf2(powerOf2) {
-		panic("Argument 'powerOf2' must be a positive power of 2.")
+		return 0, fmt.Errorf("argument 'powerOf2' must be a positive power of 2")
 	}
-	return bits.TrailingZeros64(powerOf2)
+	return bits.TrailingZeros64(powerOf2), nil
 }
 
 // isLongPowerOf2 returns true if the given number is a power of 2.

--- a/common/utils_test.go
+++ b/common/utils_test.go
@@ -18,10 +18,11 @@
 package common
 
 import (
-	"fmt"
+	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestInvPow2(t *testing.T) {
-	fmt.Printf("%f", InvPow2(0))
+	_, err := InvPow2(0)
+	assert.NoError(t, err)
 }

--- a/hll/aux_hash_map_test.go
+++ b/hll/aux_hash_map_test.go
@@ -25,20 +25,27 @@ import (
 
 func TestMustReplace(t *testing.T) {
 	auxMap := newAuxHashMap(3, 7)
-	auxMap.mustAdd(100, 5)
-	val := auxMap.mustFindValueFor(100)
+	err := auxMap.mustAdd(100, 5)
+	assert.NoError(t, err)
+	val, err := auxMap.mustFindValueFor(100)
+	assert.NoError(t, err)
 	assert.Equal(t, 5, val)
-	auxMap.mustReplace(100, 10)
-	val = auxMap.mustFindValueFor(100)
+	err = auxMap.mustReplace(100, 10)
+	assert.NoError(t, err)
+	val, err = auxMap.mustFindValueFor(100)
+	assert.NoError(t, err)
 	assert.Equal(t, 10, val)
-	assert.Panics(t, func() { auxMap.mustReplace(101, 5) }, "pair not found: SlotNo: 101, Value: 5")
+
+	err = auxMap.mustReplace(101, 5)
+	assert.Error(t, err, "pair not found: SlotNo: 101, Value: 5")
 }
 
 func TestGrowAuxSpace(t *testing.T) {
 	auxMap := newAuxHashMap(3, 7)
 	assert.Equal(t, 3, auxMap.getLgAuxArrInts())
 	for i := 1; i <= 7; i++ {
-		auxMap.mustAdd(i, i)
+		err := auxMap.mustAdd(i, i)
+		assert.NoError(t, err)
 	}
 	assert.Equal(t, 4, auxMap.getLgAuxArrInts())
 	itr := auxMap.iterator()
@@ -50,7 +57,8 @@ func TestGrowAuxSpace(t *testing.T) {
 
 	for itr.nextAll() {
 		count2++
-		pair := itr.getPair()
+		pair, err := itr.getPair()
+		assert.NoError(t, err)
 		if pair != 0 {
 			count1++
 		}
@@ -61,12 +69,16 @@ func TestGrowAuxSpace(t *testing.T) {
 
 func TestExceptions1(t *testing.T) {
 	auxMap := newAuxHashMap(3, 7)
-	auxMap.mustAdd(100, 5)
-	assert.Panics(t, func() { auxMap.mustFindValueFor(101) }, "SlotNo not found: 101")
+	err := auxMap.mustAdd(100, 5)
+	assert.NoError(t, err)
+	_, err = auxMap.mustFindValueFor(101)
+	assert.Error(t, err, "SlotNo not found: 101")
 }
 
 func TestExceptions2(t *testing.T) {
 	auxMap := newAuxHashMap(3, 7)
-	auxMap.mustAdd(100, 5)
-	assert.Panics(t, func() { auxMap.mustAdd(100, 6) }, "found a slotNo that should not be there: SlotNo: 100, Value: 6")
+	err := auxMap.mustAdd(100, 5)
+	assert.NoError(t, err)
+	err = auxMap.mustAdd(100, 6)
+	assert.Error(t, err, "found a slotNo that should not be there: SlotNo: 100, Value: 6")
 }

--- a/hll/coupon_list_test.go
+++ b/hll/coupon_list_test.go
@@ -29,7 +29,7 @@ func TestCouponIterator(t *testing.T) {
 	sk, err := NewHllSketchDefault(lgK)
 	assert.NoError(t, err)
 	for i := 0; i < n; i++ {
-		sk.UpdateInt64(int64(i))
+		assert.NoError(t, sk.UpdateInt64(int64(i)))
 	}
 
 	iter := sk.iterator()
@@ -44,31 +44,36 @@ func TestCouponDuplicatesAndMisc(t *testing.T) {
 	sk, err := NewHllSketchDefault(8)
 	assert.NoError(t, err)
 	for i := 1; i <= 7; i++ {
-		sk.UpdateInt64(int64(i))
-		sk.UpdateInt64(int64(i))
+		assert.NoError(t, sk.UpdateInt64(int64(i)))
+		assert.NoError(t, sk.UpdateInt64(int64(i)))
 	}
-	assert.Equal(t, sk.GetCurMode(), curMode_LIST)
-	est := sk.GetCompositeEstimate()
+	assert.Equal(t, sk.GetCurMode(), curModeList)
+	est, err := sk.GetCompositeEstimate()
+	assert.NoError(t, err)
 	assert.InDelta(t, est, 7.0, 7*.01)
-	est = sk.GetHipEstimate()
+	est, err = sk.GetHipEstimate()
+	assert.NoError(t, err)
 	assert.InDelta(t, est, 7.0, 7*.01)
 	sk.(*hllSketchImpl).putRebuildCurMinNumKxQFlag(false) //dummy
 
-	sk.UpdateInt64(8)
-	sk.UpdateInt64(8)
-	assert.Equal(t, sk.GetCurMode(), curMode_SET)
-	est = sk.GetCompositeEstimate()
+	assert.NoError(t, sk.UpdateInt64(8))
+	assert.NoError(t, sk.UpdateInt64(8))
+	assert.Equal(t, sk.GetCurMode(), curModeSet)
+	est, err = sk.GetCompositeEstimate()
+	assert.NoError(t, err)
 	assert.InDelta(t, est, 8.0, 8*.01)
-	est = sk.GetHipEstimate()
+	est, err = sk.GetHipEstimate()
+	assert.NoError(t, err)
 	assert.InDelta(t, est, 8.0, 8*.01)
 
 	for i := 9; i <= 25; i++ {
-		sk.UpdateInt64(int64(i))
-		sk.UpdateInt64(int64(i))
+		assert.NoError(t, sk.UpdateInt64(int64(i)))
+		assert.NoError(t, sk.UpdateInt64(int64(i)))
 	}
 
-	assert.Equal(t, sk.GetCurMode(), curMode_HLL)
-	est = sk.GetCompositeEstimate()
+	assert.Equal(t, sk.GetCurMode(), curModeHll)
+	est, err = sk.GetCompositeEstimate()
+	assert.NoError(t, err)
 	assert.InDelta(t, est, 25.0, 25*.1)
 }
 
@@ -88,26 +93,29 @@ func toCouponSliceDeserialize(t *testing.T, lgK int) {
 	}
 
 	for i := 0; i < u; i++ {
-		sk1.UpdateInt64(int64(i))
+		assert.NoError(t, sk1.UpdateInt64(int64(i)))
 	}
 
 	_, isCoupon := sk1.(*hllSketchImpl).sketch.(hllCoupon)
 	assert.True(t, isCoupon)
 
-	est1 := sk1.GetEstimate()
+	est1, err := sk1.GetEstimate()
+	assert.NoError(t, err)
 	assert.InDelta(t, est1, float64(u), float64(u)*100.0e-6)
 
 	sl1, err := sk1.ToCompactSlice()
 	assert.NoError(t, err)
-	sk2, e := DeserializeHllSketch(sl1, true)
-	assert.NoError(t, e)
-	est2 := sk2.GetEstimate()
+	sk2, err := DeserializeHllSketch(sl1, true)
+	assert.NoError(t, err)
+	est2, err := sk2.GetEstimate()
+	assert.NoError(t, err)
 	assert.Equal(t, est2, est1)
 
 	sl1, err = sk1.ToUpdatableSlice()
 	assert.NoError(t, err)
-	sk2, e = DeserializeHllSketch(sl1, true)
-	assert.NoError(t, e)
-	est2 = sk2.GetEstimate()
+	sk2, err = DeserializeHllSketch(sl1, true)
+	assert.NoError(t, err)
+	est2, err = sk2.GetEstimate()
+	assert.NoError(t, err)
 	assert.Equal(t, est2, est1)
 }

--- a/hll/cross_counting_test.go
+++ b/hll/cross_counting_test.go
@@ -32,43 +32,49 @@ func TestCrossCounting(t *testing.T) {
 }
 
 func crossCountingCheck(t *testing.T, lgK int, n int) {
-	sk4, err := buildSketch(lgK, n, TgtHllType_HLL_4)
+	sk4, err := buildSketch(lgK, n, TgtHllTypeHll4)
 	assert.NoError(t, err)
 	s4csum := computeCheckSum(t, sk4)
 
-	sk6, err := buildSketch(lgK, n, TgtHllType_HLL_6)
+	sk6, err := buildSketch(lgK, n, TgtHllTypeHll6)
 	assert.NoError(t, err)
 	s6csum := computeCheckSum(t, sk6)
 
 	assert.Equal(t, s6csum, s4csum)
 
-	sk8, err := buildSketch(lgK, n, TgtHllType_HLL_8)
+	sk8, err := buildSketch(lgK, n, TgtHllTypeHll8)
 	assert.NoError(t, err)
 	s8csum := computeCheckSum(t, sk8)
 	assert.Equal(t, s8csum, s4csum)
 
 	// Conversions
-	sk6to4 := sk6.CopyAs(TgtHllType_HLL_4)
+	sk6to4, err := sk6.CopyAs(TgtHllTypeHll4)
+	assert.NoError(t, err)
 	sk6to4csum := computeCheckSum(t, sk6to4)
 	assert.Equal(t, sk6to4csum, s4csum)
 
-	sk8to4 := sk8.CopyAs(TgtHllType_HLL_4)
+	sk8to4, err := sk8.CopyAs(TgtHllTypeHll4)
+	assert.NoError(t, err)
 	sk8to4csum := computeCheckSum(t, sk8to4)
 	assert.Equal(t, sk8to4csum, s4csum)
 
-	sk4to6 := sk4.CopyAs(TgtHllType_HLL_6)
+	sk4to6, err := sk4.CopyAs(TgtHllTypeHll6)
+	assert.NoError(t, err)
 	sk4to6csum := computeCheckSum(t, sk4to6)
 	assert.Equal(t, sk4to6csum, s4csum)
 
-	sk8to6 := sk8.CopyAs(TgtHllType_HLL_6)
+	sk8to6, err := sk8.CopyAs(TgtHllTypeHll6)
+	assert.NoError(t, err)
 	sk8to6csum := computeCheckSum(t, sk8to6)
 	assert.Equal(t, sk8to6csum, s4csum)
 
-	sk4to8 := sk4.CopyAs(TgtHllType_HLL_8)
+	sk4to8, err := sk4.CopyAs(TgtHllTypeHll8)
+	assert.NoError(t, err)
 	sk4to8csum := computeCheckSum(t, sk4to8)
 	assert.Equal(t, sk4to8csum, s4csum)
 
-	sk6to8 := sk6.CopyAs(TgtHllType_HLL_8)
+	sk6to8, err := sk6.CopyAs(TgtHllTypeHll8)
+	assert.NoError(t, err)
 	sk6to8csum := computeCheckSum(t, sk6to8)
 	assert.Equal(t, sk6to8csum, s4csum)
 
@@ -80,7 +86,10 @@ func buildSketch(lgK int, n int, tgtHllType TgtHllType) (HllSketch, error) {
 		return nil, err
 	}
 	for i := 0; i < n; i++ {
-		sketch.UpdateInt64(int64(i))
+		err = sketch.UpdateInt64(int64(i))
+		if err != nil {
+			return nil, err
+		}
 	}
 	return sketch, nil
 }
@@ -89,7 +98,8 @@ func computeCheckSum(t *testing.T, sketch HllSketch) int {
 	itr := sketch.iterator()
 	checksum := 0
 	for itr.nextAll() {
-		p := itr.getPair()
+		p, err := itr.getPair()
+		assert.NoError(t, err)
 		checksum += p
 		_ = itr.getKey()
 	}

--- a/hll/cubic_interpolation.go
+++ b/hll/cubic_interpolation.go
@@ -20,28 +20,31 @@ package hll
 import "fmt"
 
 // UsingXAndYTables returns the cubic interpolation using the X and Y tables.
-func usingXAndYTables(xArr []float64, yArr []float64, x float64) float64 {
+func usingXAndYTables(xArr []float64, yArr []float64, x float64) (float64, error) {
 	if len(xArr) < 4 || len(xArr) != len(yArr) {
-		panic(fmt.Sprintf("X value out of range: %f", x))
+		return 0, fmt.Errorf("X value out of range: %f", x)
 	}
 
 	if x == xArr[len(xArr)-1] {
-		return yArr[len(yArr)-1] // corer case
+		return yArr[len(yArr)-1], nil // corer case
 	}
 
-	offset := findStraddle(xArr, x) //uses recursion
+	offset, err := findStraddle(xArr, x) //uses recursion
+	if err != nil {
+		return 0, err
+	}
 	if (offset < 0) || (offset > (len(xArr) - 2)) {
-		panic(fmt.Sprintf("offset out of range: %d", offset))
+		return 0, fmt.Errorf("offset out of range: %d", offset)
 	}
 	if offset == 0 {
-		return interpolateUsingXAndYTables(xArr, yArr, offset, x) // corner case
+		return interpolateUsingXAndYTables(xArr, yArr, offset, x), nil // corner case
 	}
 
 	if offset == len(xArr)-2 {
-		return interpolateUsingXAndYTables(xArr, yArr, offset-2, x) // corner case
+		return interpolateUsingXAndYTables(xArr, yArr, offset-2, x), nil // corner case
 	}
 
-	return interpolateUsingXAndYTables(xArr, yArr, offset-1, x)
+	return interpolateUsingXAndYTables(xArr, yArr, offset-1, x), nil
 }
 
 func interpolateUsingXAndYTables(xArr []float64, yArr []float64, offset int, x float64) float64 {
@@ -53,28 +56,31 @@ func interpolateUsingXAndYTables(xArr []float64, yArr []float64, offset int, x f
 		x)
 }
 
-func usingXArrAndYStride(xArr []float64, yStride float64, x float64) float64 {
+func usingXArrAndYStride(xArr []float64, yStride float64, x float64) (float64, error) {
 	xArrLen := len(xArr)
 	xArrLenM1 := xArrLen - 1
 
 	if xArrLen < 4 || x < xArr[0] || x > xArr[xArrLenM1] {
-		panic(fmt.Sprintf("X value out of range: %f", x))
+		return 0, fmt.Errorf("X value out of range: %f", x)
 	}
 	if x == xArr[xArrLenM1] {
-		return yStride * float64(xArrLenM1) // corner case
+		return yStride * float64(xArrLenM1), nil // corner case
 	}
-	offset := findStraddle(xArr, x) //uses recursion
+	offset, err := findStraddle(xArr, x) //uses recursion
+	if err != nil {
+		return 0, err
+	}
 	xArrLenM2 := xArrLen - 2
 	if (offset < 0) || (offset > xArrLenM2) {
-		panic(fmt.Sprintf("offset out of range: %d", offset))
+		return 0, fmt.Errorf("offset out of range: %d", offset)
 	}
 	if offset == 0 {
-		return interpolateUsingXArrAndYStride(xArr, yStride, offset, x) // corner case
+		return interpolateUsingXArrAndYStride(xArr, yStride, offset, x), nil // corner case
 	}
 	if offset == xArrLenM2 {
-		return interpolateUsingXArrAndYStride(xArr, yStride, offset-2, x) // corner case
+		return interpolateUsingXArrAndYStride(xArr, yStride, offset-2, x), nil // corner case
 	}
-	return interpolateUsingXArrAndYStride(xArr, yStride, offset-1, x)
+	return interpolateUsingXArrAndYStride(xArr, yStride, offset-1, x), nil
 }
 
 // interpolateUsingXArrAndYStride interpolates using the X array and the Y stride.
@@ -107,25 +113,25 @@ func cubicInterpolate(x0 float64, y0 float64, x1 float64, y1 float64, x2 float64
 }
 
 // findStraddle returns the index of the largest value in the array that is less than or equal to the given value.
-func findStraddle(xArr []float64, x float64) int {
+func findStraddle(xArr []float64, x float64) (int, error) {
 	if len(xArr) < 2 || x < xArr[0] || x > xArr[len(xArr)-1] {
-		panic(fmt.Sprintf("X value out of range: %f", x))
+		return 0, fmt.Errorf("X value out of range: %f", x)
 	}
 	return recursiveFindStraddle(xArr, 0, len(xArr)-1, x)
 }
 
 // recursiveFindStraddle returns the index of the largest value in the array that is less than or equal to the given value.
-func recursiveFindStraddle(xArr []float64, left int, right int, x float64) int {
+func recursiveFindStraddle(xArr []float64, left int, right int, x float64) (int, error) {
 	if left >= right {
-		panic(fmt.Sprintf("left >= right: %d >= %d", left, right))
+		return 0, fmt.Errorf("left >= right: %d >= %d", left, right)
 	}
 
 	if xArr[left] > x || x >= xArr[right] {
-		panic(fmt.Sprintf("X value out of range: %f", x))
+		return 0, fmt.Errorf("X value out of range: %f", x)
 	}
 
 	if left+1 == right {
-		return left
+		return left, nil
 	}
 
 	middle := left + ((right - left) / 2)

--- a/hll/cubic_interpolation_test.go
+++ b/hll/cubic_interpolation_test.go
@@ -24,15 +24,18 @@ import (
 )
 
 func TestInterpolationExceptions(t *testing.T) {
-	assert.Panics(t, func() { usingXAndYTables(couponMappingXArr, couponMappingYArr, -1) }, "X value out of range: -1.000000")
+	_, err := usingXAndYTables(couponMappingXArr, couponMappingYArr, -1)
+	assert.Error(t, err, "X value out of range: -1.000000")
 
-	assert.Panics(t, func() { usingXAndYTables(couponMappingXArr, couponMappingYArr, 11000000.0) }, "X value out of range: 11000000.000000")
+	_, err = usingXAndYTables(couponMappingXArr, couponMappingYArr, 11000000.0)
+	assert.Error(t, err, "X value out of range: 11000000.000000")
 }
 
 func TestCornerCases(t *testing.T) {
 	leng := len(couponMappingXArr)
 	x := couponMappingXArr[leng-1]
-	y := usingXAndYTables(couponMappingXArr, couponMappingYArr, x)
+	y, err := usingXAndYTables(couponMappingXArr, couponMappingYArr, x)
+	assert.NoError(t, err)
 	yExp := couponMappingYArr[leng-1]
 	assert.Equal(t, y, yExp)
 }

--- a/hll/hll_4array.go
+++ b/hll/hll_4array.go
@@ -26,13 +26,13 @@ type hll4ArrayImpl struct {
 	hllArrayImpl
 }
 
-func (h *hll4ArrayImpl) getSlotValue(slotNo int) int {
+func (h *hll4ArrayImpl) getSlotValue(slotNo int) (int, error) {
 	nib := h.getNibble(slotNo)
 	if nib == auxToken {
 		auxHashMap := h.getAuxHashMap()
 		return auxHashMap.mustFindValueFor(slotNo)
 	} else {
-		return nib + h.curMin
+		return nib + h.curMin, nil
 	}
 }
 
@@ -65,23 +65,23 @@ func (h *hll4ArrayImpl) GetUpdatableSerializationBytes() int {
 	return hllByteArrStart + h.getHllByteArrBytes() + auxBytes
 }
 
-func (h *hll4ArrayImpl) copyAs(tgtHllType TgtHllType) hllSketchBase {
+func (h *hll4ArrayImpl) copyAs(tgtHllType TgtHllType) (hllSketchBase, error) {
 	if tgtHllType == h.tgtHllType {
 		return h.copy()
 	}
-	if tgtHllType == TgtHllType_HLL_6 {
+	if tgtHllType == TgtHllTypeHll6 {
 		return convertToHll6(h)
 	}
-	if tgtHllType == TgtHllType_HLL_8 {
+	if tgtHllType == TgtHllTypeHll8 {
 		return convertToHll8(h)
 	}
-	panic(fmt.Sprintf("Cannot convert to TgtHllType id: %d ", int(tgtHllType)))
+	return nil, fmt.Errorf("cannot convert to TgtHllType id: %d ", int(tgtHllType))
 }
 
-func (h *hll4ArrayImpl) copy() hllSketchBase {
+func (h *hll4ArrayImpl) copy() (hllSketchBase, error) {
 	return &hll4ArrayImpl{
 		hllArrayImpl: h.copyCommon(),
-	}
+	}, nil
 }
 
 // newHll4Array returns a new Hll4Array.
@@ -90,8 +90,8 @@ func newHll4Array(lgConfigK int) hllArray {
 		hllArrayImpl: hllArrayImpl{
 			hllSketchConfig: hllSketchConfig{
 				lgConfigK:  lgConfigK,
-				tgtHllType: TgtHllType_HLL_4,
-				curMode:    curMode_HLL,
+				tgtHllType: TgtHllTypeHll4,
+				curMode:    curModeHll,
 			},
 			curMin:      0,
 			numAtCurMin: 1 << lgConfigK,
@@ -105,7 +105,7 @@ func newHll4Array(lgConfigK int) hllArray {
 }
 
 // deserializeHll4 returns a new Hll4Array from the given byte array.
-func deserializeHll4(byteArray []byte) hllArray {
+func deserializeHll4(byteArray []byte) (hllArray, error) {
 	lgConfigK := extractLgK(byteArray)
 	hll4 := newHll4Array(lgConfigK)
 	hll4.extractCommonHll(byteArray)
@@ -115,20 +115,26 @@ func deserializeHll4(byteArray []byte) hllArray {
 	compact := extractCompactFlag(byteArray)
 
 	if auxCount > 0 {
-		auxHashMap := deserializeAuxHashMap(byteArray, auxStart, lgConfigK, auxCount, compact)
+		auxHashMap, err := deserializeAuxHashMap(byteArray, auxStart, lgConfigK, auxCount, compact)
+		if err != nil {
+			return nil, err
+		}
 		hll4.putAuxHashMap(auxHashMap, false)
 	}
 
-	return hll4
+	return hll4, nil
 }
 
-func convertToHll4(srcAbsHllArr hllArray) hllSketchBase {
+func convertToHll4(srcAbsHllArr hllArray) (hllSketchBase, error) {
 	lgConfigK := srcAbsHllArr.GetLgConfigK()
 	hll4Array := newHll4Array(lgConfigK)
 	hll4Array.putOutOfOrder(srcAbsHllArr.isOutOfOrder())
 
 	// 1st pass: compute starting curMin and numAtCurMin:
-	pair := curMinAndNum(srcAbsHllArr)
+	pair, err := curMinAndNum(srcAbsHllArr)
+	if err != nil {
+		return nil, err
+	}
 	curMin := getPairValue(pair)
 	numAtCurMin := getPairLow26(pair)
 
@@ -138,15 +144,24 @@ func convertToHll4(srcAbsHllArr hllArray) hllSketchBase {
 	auxHashMap := hll4Array.getAuxHashMap() //may be null
 	for srcItr.nextValid() {
 		slotNo := srcItr.getIndex()
-		actualValue := srcItr.getValue()
-		hll4Array.hipAndKxQIncrementalUpdate(0, actualValue)
+		actualValue, err := srcItr.getValue()
+		if err != nil {
+			return nil, err
+		}
+		err = hll4Array.hipAndKxQIncrementalUpdate(0, actualValue)
+		if err != nil {
+			return nil, err
+		}
 		if actualValue >= (curMin + 15) {
 			hll4Array.putNibble(slotNo, auxToken)
 			if auxHashMap == nil {
 				auxHashMap = newAuxHashMap(lgAuxArrInts[lgConfigK], lgConfigK)
 				hll4Array.putAuxHashMap(auxHashMap, false)
 			}
-			auxHashMap.mustAdd(slotNo, actualValue)
+			err := auxHashMap.mustAdd(slotNo, actualValue)
+			if err != nil {
+				return nil, err
+			}
 		} else {
 			hll4Array.putNibble(slotNo, byte(actualValue-curMin))
 		}
@@ -155,24 +170,27 @@ func convertToHll4(srcAbsHllArr hllArray) hllSketchBase {
 	hll4Array.putNumAtCurMin(numAtCurMin)
 	hll4Array.putHipAccum(srcAbsHllArr.getHipAccum()) //intentional overwrite
 	hll4Array.putRebuildCurMinNumKxQFlag(false)
-	return hll4Array
+	return hll4Array, nil
 }
 
 // couponUpdate updates the Hll4Array with the given coupon and returns the updated Hll4Array.
-func (h *hll4ArrayImpl) couponUpdate(coupon int) hllSketchBase {
+func (h *hll4ArrayImpl) couponUpdate(coupon int) (hllSketchBase, error) {
 	newValue := coupon >> keyBits26
 	configKmask := (1 << h.lgConfigK) - 1
 	slotNo := coupon & configKmask
-	internalHll4Update(h, slotNo, newValue)
-	return h
+	err := internalHll4Update(h, slotNo, newValue)
+	return h, err
 }
 
-func curMinAndNum(absHllArr hllArray) int {
+func curMinAndNum(absHllArr hllArray) (int, error) {
 	curMin := 64
 	numAtCurMin := 0
 	itr := absHllArr.iterator()
 	for itr.nextAll() {
-		v := itr.getValue()
+		v, err := itr.getValue()
+		if err != nil {
+			return 0, err
+		}
 		if v > curMin {
 			continue
 		}
@@ -183,7 +201,7 @@ func curMinAndNum(absHllArr hllArray) int {
 			numAtCurMin++
 		}
 	}
-	return pair(numAtCurMin, curMin)
+	return pair(numAtCurMin, curMin), nil
 }
 
 func newHll4Iterator(lengthPairs int, hll *hll4ArrayImpl) hll4Iterator {
@@ -193,11 +211,11 @@ func newHll4Iterator(lengthPairs int, hll *hll4ArrayImpl) hll4Iterator {
 	}
 }
 
-func (itr *hll4Iterator) getValue() int {
+func (itr *hll4Iterator) getValue() (int, error) {
 	return itr.hll.getSlotValue(itr.getIndex())
 }
 
-func (itr *hll4Iterator) getPair() int {
-	v := itr.getValue()
-	return pair(itr.index, v)
+func (itr *hll4Iterator) getPair() (int, error) {
+	v, err := itr.getValue()
+	return pair(itr.index, v), err
 }

--- a/hll/hll_array_test.go
+++ b/hll/hll_array_test.go
@@ -24,20 +24,20 @@ import (
 )
 
 func TestCompositeEst(t *testing.T) {
-	testComposite(t, 4, TgtHllType_HLL_4, 1000)
-	testComposite(t, 5, TgtHllType_HLL_4, 1000)
-	testComposite(t, 6, TgtHllType_HLL_4, 1000)
-	testComposite(t, 13, TgtHllType_HLL_4, 10000)
+	testComposite(t, 4, TgtHllTypeHll4, 1000)
+	testComposite(t, 5, TgtHllTypeHll4, 1000)
+	testComposite(t, 6, TgtHllTypeHll4, 1000)
+	testComposite(t, 13, TgtHllTypeHll4, 10000)
 
-	testComposite(t, 4, TgtHllType_HLL_6, 1000)
-	testComposite(t, 5, TgtHllType_HLL_6, 1000)
-	testComposite(t, 6, TgtHllType_HLL_6, 1000)
-	testComposite(t, 13, TgtHllType_HLL_6, 10000)
+	testComposite(t, 4, TgtHllTypeHll6, 1000)
+	testComposite(t, 5, TgtHllTypeHll6, 1000)
+	testComposite(t, 6, TgtHllTypeHll6, 1000)
+	testComposite(t, 13, TgtHllTypeHll6, 10000)
 
-	testComposite(t, 4, TgtHllType_HLL_8, 1000)
-	testComposite(t, 5, TgtHllType_HLL_8, 1000)
-	testComposite(t, 6, TgtHllType_HLL_8, 1000)
-	testComposite(t, 13, TgtHllType_HLL_8, 10000)
+	testComposite(t, 4, TgtHllTypeHll8, 1000)
+	testComposite(t, 5, TgtHllTypeHll8, 1000)
+	testComposite(t, 6, TgtHllTypeHll8, 1000)
+	testComposite(t, 13, TgtHllTypeHll8, 10000)
 }
 
 func testComposite(t *testing.T, lgK int, tgtHllType TgtHllType, n int) {
@@ -47,43 +47,46 @@ func testComposite(t *testing.T, lgK int, tgtHllType TgtHllType, n int) {
 	assert.NoError(t, err)
 
 	for i := 0; i < n; i++ {
-		u.UpdateInt64(int64(i))
-		sk.UpdateInt64(int64(i))
+		assert.NoError(t, u.UpdateInt64(int64(i)))
+		assert.NoError(t, sk.UpdateInt64(int64(i)))
 	}
 
-	u.UpdateSketch(sk)
+	err = u.UpdateSketch(sk)
+	assert.NoError(t, err)
 	res, err := u.GetResult(tgtHllType)
 	assert.NoError(t, err)
-	res.GetCompositeEstimate()
+	_, err = res.GetCompositeEstimate()
+	assert.NoError(t, err)
+
 }
 
 func TestBigHipGetRse(t *testing.T) {
-	sk, err := NewHllSketch(13, TgtHllType_HLL_8)
+	sk, err := NewHllSketch(13, TgtHllTypeHll8)
 	assert.NoError(t, err)
 
 	for i := 0; i < 10000; i++ {
-		sk.UpdateInt64(int64(i))
+		assert.NoError(t, sk.UpdateInt64(int64(i)))
 	}
 }
 
 func TestToArraySliceDeserialize(t *testing.T) {
 	lgK := 4
 	u := 8
-	toArraySliceDeserialize(t, lgK, TgtHllType_HLL_4, u)
-	toArraySliceDeserialize(t, lgK, TgtHllType_HLL_6, u)
-	toArraySliceDeserialize(t, lgK, TgtHllType_HLL_8, u)
+	toArraySliceDeserialize(t, lgK, TgtHllTypeHll4, u)
+	toArraySliceDeserialize(t, lgK, TgtHllTypeHll6, u)
+	toArraySliceDeserialize(t, lgK, TgtHllTypeHll8, u)
 
 	lgK = 16
 	u = (((1 << (lgK - 3)) * 3) / 4) + 100
-	toArraySliceDeserialize(t, lgK, TgtHllType_HLL_4, u)
-	toArraySliceDeserialize(t, lgK, TgtHllType_HLL_6, u)
-	toArraySliceDeserialize(t, lgK, TgtHllType_HLL_8, u)
+	toArraySliceDeserialize(t, lgK, TgtHllTypeHll4, u)
+	toArraySliceDeserialize(t, lgK, TgtHllTypeHll6, u)
+	toArraySliceDeserialize(t, lgK, TgtHllTypeHll8, u)
 
 	lgK = 21
 	u = (((1 << (lgK - 3)) * 3) / 4) + 1000
-	toArraySliceDeserialize(t, lgK, TgtHllType_HLL_4, u)
-	toArraySliceDeserialize(t, lgK, TgtHllType_HLL_6, u)
-	toArraySliceDeserialize(t, lgK, TgtHllType_HLL_8, u)
+	toArraySliceDeserialize(t, lgK, TgtHllTypeHll4, u)
+	toArraySliceDeserialize(t, lgK, TgtHllTypeHll6, u)
+	toArraySliceDeserialize(t, lgK, TgtHllTypeHll8, u)
 }
 
 func toArraySliceDeserialize(t *testing.T, lgK int, tgtHllType TgtHllType, u int) {
@@ -91,15 +94,17 @@ func toArraySliceDeserialize(t *testing.T, lgK int, tgtHllType TgtHllType, u int
 	assert.NoError(t, err)
 
 	for i := 0; i < u; i++ {
-		sk1.UpdateInt64(int64(i))
+		assert.NoError(t, sk1.UpdateInt64(int64(i)))
 	}
 	_, isArray := sk1.(*hllSketchImpl).sketch.(hllArray)
 	assert.True(t, isArray)
 
 	// Update
-	est1 := sk1.GetEstimate()
+	est1, err := sk1.GetEstimate()
+	assert.NoError(t, err)
 	assert.InDelta(t, est1, u, float64(u)*.03)
-	est := sk1.GetHipEstimate()
+	est, err := sk1.GetHipEstimate()
+	assert.NoError(t, err)
 	assert.Equal(t, est, est1, 0.0)
 
 	// misc
@@ -110,11 +115,13 @@ func toArraySliceDeserialize(t *testing.T, lgK int, tgtHllType TgtHllType, u int
 	assert.NoError(t, err)
 	sk2, e := DeserializeHllSketch(sl1, true)
 	assert.NoError(t, e)
-	est2 := sk2.GetEstimate()
+	est2, err := sk2.GetEstimate()
+	assert.NoError(t, err)
 	assert.Equal(t, est2, est1, 0.0)
 
 	err = sk1.Reset()
 	assert.NoError(t, err)
-	est = sk1.GetEstimate()
+	est, err = sk1.GetEstimate()
+	assert.NoError(t, err)
 	assert.Equal(t, est, 0.0, 0.0)
 }

--- a/hll/hll_sketch_serialization_test.go
+++ b/hll/hll_sketch_serialization_test.go
@@ -26,31 +26,31 @@ import (
 )
 
 const (
-	DSKETCH_TEST_GENERATE_GO = "DSKETCH_TEST_GENERATE_GO"
-	DSKETCH_TEST_CROSS_JAVA  = "DSKETCH_TEST_CROSS_JAVA"
-	DSKETCH_TEST_CROSS_CPP   = "DSKETCH_TEST_CROSS_CPP"
-	DSKETCH_TEST_CROSS_GO    = "DSKETCH_TEST_CROSS_GO"
+	dSketchTestGenerateGo = "DSKETCH_TEST_GENERATE_GO"
+	dSketchTestCrossJava  = "DSKETCH_TEST_CROSS_JAVA"
+	dSketchTestCrossCpp   = "DSKETCH_TEST_CROSS_CPP"
+	dSketchTestCrossGo    = "DSKETCH_TEST_CROSS_GO"
 )
 
 // Run me manually for generation
 func TestGenerateGoFiles(t *testing.T) {
-	if len(os.Getenv(DSKETCH_TEST_GENERATE_GO)) == 0 {
-		t.Skipf("%s not set", DSKETCH_TEST_GENERATE_GO)
+	if len(os.Getenv(dSketchTestGenerateGo)) == 0 {
+		t.Skipf("%s not set", dSketchTestGenerateGo)
 	}
 
 	nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 	for _, n := range nArr {
-		hll4, err := NewHllSketch(defaultLgK, TgtHllType_HLL_4)
+		hll4, err := NewHllSketch(defaultLgK, TgtHllTypeHll4)
 		assert.NoError(t, err)
-		hll6, err := NewHllSketch(defaultLgK, TgtHllType_HLL_6)
+		hll6, err := NewHllSketch(defaultLgK, TgtHllTypeHll6)
 		assert.NoError(t, err)
-		hll8, err := NewHllSketch(defaultLgK, TgtHllType_HLL_8)
+		hll8, err := NewHllSketch(defaultLgK, TgtHllTypeHll8)
 		assert.NoError(t, err)
 
 		for i := 0; i < n; i++ {
-			hll4.UpdateUInt64(uint64(i))
-			hll6.UpdateUInt64(uint64(i))
-			hll8.UpdateUInt64(uint64(i))
+			assert.NoError(t, hll4.UpdateUInt64(uint64(i)))
+			assert.NoError(t, hll6.UpdateUInt64(uint64(i)))
+			assert.NoError(t, hll8.UpdateUInt64(uint64(i)))
 		}
 		err = os.MkdirAll(goPath, os.ModePerm)
 		assert.NoError(t, err)
@@ -73,8 +73,8 @@ func TestGenerateGoFiles(t *testing.T) {
 }
 
 func TestJavaCompat(t *testing.T) {
-	if len(os.Getenv(DSKETCH_TEST_CROSS_JAVA)) == 0 {
-		t.Skipf("%s not set", DSKETCH_TEST_CROSS_JAVA)
+	if len(os.Getenv(dSketchTestCrossJava)) == 0 {
+		t.Skipf("%s not set", dSketchTestCrossJava)
 	}
 
 	t.Run("Java Hll4", func(t *testing.T) {
@@ -88,7 +88,8 @@ func TestJavaCompat(t *testing.T) {
 			}
 
 			assert.Equal(t, 12, sketch.GetLgConfigK())
-			est := sketch.GetEstimate()
+			est, err := sketch.GetEstimate()
+			assert.NoError(t, err)
 			assert.InDelta(t, n, est, float64(n)*0.02)
 		}
 	})
@@ -105,7 +106,8 @@ func TestJavaCompat(t *testing.T) {
 			}
 
 			assert.Equal(t, 12, sketch.GetLgConfigK())
-			est := sketch.GetEstimate()
+			est, err := sketch.GetEstimate()
+			assert.NoError(t, err)
 			assert.InDelta(t, n, est, float64(n)*0.02)
 		}
 	})
@@ -121,15 +123,16 @@ func TestJavaCompat(t *testing.T) {
 			}
 
 			assert.Equal(t, 12, sketch.GetLgConfigK())
-			est := sketch.GetEstimate()
+			est, err := sketch.GetEstimate()
+			assert.NoError(t, err)
 			assert.InDelta(t, n, est, float64(n)*0.02)
 		}
 	})
 }
 
 func TestCppCompat(t *testing.T) {
-	if len(os.Getenv(DSKETCH_TEST_CROSS_CPP)) == 0 {
-		t.Skipf("%s not set", DSKETCH_TEST_CROSS_CPP)
+	if len(os.Getenv(dSketchTestCrossCpp)) == 0 {
+		t.Skipf("%s not set", dSketchTestCrossCpp)
 	}
 
 	t.Run("Cpp Hll4", func(t *testing.T) {
@@ -143,7 +146,8 @@ func TestCppCompat(t *testing.T) {
 			}
 
 			assert.Equal(t, 12, sketch.GetLgConfigK())
-			est := sketch.GetEstimate()
+			est, err := sketch.GetEstimate()
+			assert.NoError(t, err)
 			assert.InDelta(t, n, est, float64(n)*0.02)
 		}
 	})
@@ -160,7 +164,8 @@ func TestCppCompat(t *testing.T) {
 			}
 
 			assert.Equal(t, 12, sketch.GetLgConfigK())
-			est := sketch.GetEstimate()
+			est, err := sketch.GetEstimate()
+			assert.NoError(t, err)
 			assert.InDelta(t, n, est, float64(n)*0.02)
 		}
 	})
@@ -176,15 +181,16 @@ func TestCppCompat(t *testing.T) {
 			}
 
 			assert.Equal(t, 12, sketch.GetLgConfigK())
-			est := sketch.GetEstimate()
+			est, err := sketch.GetEstimate()
+			assert.NoError(t, err)
 			assert.InDelta(t, n, est, float64(n)*0.02)
 		}
 	})
 }
 
 func TestGoCompat(t *testing.T) {
-	if len(os.Getenv(DSKETCH_TEST_CROSS_GO)) == 0 {
-		t.Skipf("%s not set", DSKETCH_TEST_CROSS_GO)
+	if len(os.Getenv(dSketchTestCrossGo)) == 0 {
+		t.Skipf("%s not set", dSketchTestCrossGo)
 	}
 
 	t.Run("Go Hll4", func(t *testing.T) {
@@ -199,7 +205,8 @@ func TestGoCompat(t *testing.T) {
 			}
 
 			assert.Equal(t, 12, sketch.GetLgConfigK())
-			est := sketch.GetEstimate()
+			est, err := sketch.GetEstimate()
+			assert.NoError(t, err)
 			assert.InDelta(t, n, est, float64(n)*0.02)
 		}
 	})
@@ -216,7 +223,8 @@ func TestGoCompat(t *testing.T) {
 			}
 
 			assert.Equal(t, 12, sketch.GetLgConfigK())
-			est := sketch.GetEstimate()
+			est, err := sketch.GetEstimate()
+			assert.NoError(t, err)
 			assert.InDelta(t, n, est, float64(n)*0.02)
 		}
 	})
@@ -233,7 +241,8 @@ func TestGoCompat(t *testing.T) {
 			}
 
 			assert.Equal(t, 12, sketch.GetLgConfigK())
-			est := sketch.GetEstimate()
+			est, err := sketch.GetEstimate()
+			assert.NoError(t, err)
 			assert.InDelta(t, n, est, float64(n)*0.02)
 		}
 	})

--- a/hll/hll_sketch_test.go
+++ b/hll/hll_sketch_test.go
@@ -33,7 +33,7 @@ const (
 )
 
 func TestMisc(t *testing.T) {
-	hll, err := NewHllSketch(10, TgtHllType_HLL_4)
+	hll, err := NewHllSketch(10, TgtHllTypeHll4)
 	assert.NoError(t, err)
 	assert.True(t, hll.IsEstimationMode())
 	err = hll.Reset()
@@ -42,104 +42,116 @@ func TestMisc(t *testing.T) {
 }
 
 func TestUpdateTypes(t *testing.T) {
-	checkUpdateType(t, TgtHllType_HLL_4)
-	checkUpdateType(t, TgtHllType_HLL_6)
-	checkUpdateType(t, TgtHllType_HLL_8)
+	checkUpdateType(t, TgtHllTypeHll4)
+	checkUpdateType(t, TgtHllTypeHll6)
+	checkUpdateType(t, TgtHllTypeHll8)
 }
 
 func checkUpdateType(t *testing.T, tgtHllType TgtHllType) {
 	hll, err := NewHllSketch(11, tgtHllType)
 	assert.NoError(t, err)
 
-	hll.UpdateSlice(nil)
-	hll.UpdateSlice(make([]byte, 0))
-	hll.UpdateSlice([]byte{1, 2, 3})
-	hll.UpdateString("")
-	hll.UpdateString("abc")
+	assert.NoError(t, hll.UpdateSlice(nil))
+	assert.NoError(t, hll.UpdateSlice(make([]byte, 0)))
+	assert.NoError(t, hll.UpdateSlice([]byte{1, 2, 3}))
+	assert.NoError(t, hll.UpdateString(""))
+	assert.NoError(t, hll.UpdateString("abc"))
 
-	hll.UpdateInt64(0)
-	hll.UpdateInt64(1)
-	hll.UpdateInt64(-1)
+	assert.NoError(t, hll.UpdateInt64(0))
+	assert.NoError(t, hll.UpdateInt64(1))
+	assert.NoError(t, hll.UpdateInt64(-1))
 
-	hll.UpdateUInt64(0)
-	hll.UpdateUInt64(1)
+	assert.NoError(t, hll.UpdateUInt64(0))
+	assert.NoError(t, hll.UpdateUInt64(1))
 }
 
 func TestCopies(t *testing.T) {
-	checkCopy(t, 14, TgtHllType_HLL_4)
-	checkCopy(t, 8, TgtHllType_HLL_6)
-	checkCopy(t, 8, TgtHllType_HLL_8)
+	checkCopy(t, 14, TgtHllTypeHll4)
+	checkCopy(t, 8, TgtHllTypeHll6)
+	checkCopy(t, 8, TgtHllTypeHll8)
 }
 
 func checkCopy(t *testing.T, lgK int, tgtHllType TgtHllType) {
 	sk, err := NewHllSketch(lgK, tgtHllType)
 	assert.NoError(t, err)
 	for i := 0; i < 7; i++ {
-		sk.UpdateInt64(int64(i))
+		err := sk.UpdateInt64(int64(i))
+		assert.NoError(t, err)
 	}
-	assert.Equal(t, curMode_LIST, sk.GetCurMode())
+	assert.Equal(t, curModeList, sk.GetCurMode())
 
-	skCopy := sk.Copy()
-	assert.Equal(t, curMode_LIST, skCopy.GetCurMode())
+	skCopy, err := sk.Copy()
+	assert.NoError(t, err)
+	assert.Equal(t, curModeList, skCopy.GetCurMode())
 
 	impl1 := sk.(*hllSketchImpl).sketch
 	impl2 := skCopy.(*hllSketchImpl).sketch
 
 	assert.Equal(t, impl1.(*couponListImpl).couponCount, impl2.(*couponListImpl).couponCount)
 
-	est1 := impl1.GetEstimate()
-	est2 := impl2.GetEstimate()
+	est1, err := impl1.GetEstimate()
+	assert.NoError(t, err)
+	est2, err := impl2.GetEstimate()
+	assert.NoError(t, err)
 	assert.Equal(t, est1, est2)
 	assert.False(t, impl1 == impl2)
 
 	for i := 7; i < 24; i++ {
-		sk.UpdateInt64(int64(i))
+		err := sk.UpdateInt64(int64(i))
+		assert.NoError(t, err)
 	}
 
-	assert.Equal(t, curMode_SET, sk.GetCurMode())
-	skCopy = sk.Copy()
-	assert.Equal(t, curMode_SET, skCopy.GetCurMode())
+	assert.Equal(t, curModeSet, sk.GetCurMode())
+	skCopy, err = sk.Copy()
+	assert.NoError(t, err)
+	assert.Equal(t, curModeSet, skCopy.GetCurMode())
 
 	impl1 = sk.(*hllSketchImpl).sketch
 	impl2 = skCopy.(*hllSketchImpl).sketch
 
 	assert.Equal(t, impl1.(*couponHashSetImpl).couponCount, impl2.(*couponHashSetImpl).couponCount)
-	est1 = impl1.GetEstimate()
-	est2 = impl2.GetEstimate()
+	est1, err = impl1.GetEstimate()
+	assert.NoError(t, err)
+	est2, err = impl2.GetEstimate()
+	assert.NoError(t, err)
 	assert.Equal(t, est1, est2)
 	assert.False(t, impl1 == impl2)
 
 	u := 25
-	if tgtHllType == TgtHllType_HLL_4 {
+	if tgtHllType == TgtHllTypeHll4 {
 		u = 100000
 	}
 	for i := 24; i < u; i++ {
-		sk.UpdateInt64(int64(i))
+		err := sk.UpdateInt64(int64(i))
+		assert.NoError(t, err)
 	}
 
-	assert.Equal(t, curMode_HLL, sk.GetCurMode())
-	skCopy = sk.Copy()
-	assert.Equal(t, curMode_HLL, skCopy.GetCurMode())
+	assert.Equal(t, curModeHll, sk.GetCurMode())
+	skCopy, err = sk.Copy()
+	assert.NoError(t, err)
+	assert.Equal(t, curModeHll, skCopy.GetCurMode())
 
 	impl1 = sk.(*hllSketchImpl).sketch
 	impl2 = skCopy.(*hllSketchImpl).sketch
 
-	est1 = impl1.GetEstimate()
-	est2 = impl2.GetEstimate()
+	est1, err = impl1.GetEstimate()
+	assert.NoError(t, err)
+	est2, err = impl2.GetEstimate()
+	assert.NoError(t, err)
 	assert.Equal(t, est1, est2)
 	assert.False(t, impl1 == impl2)
 }
 
 func TestCopyAs(t *testing.T) {
-	checkCopyAs(t, TgtHllType_HLL_4, TgtHllType_HLL_4)
-	checkCopyAs(t, TgtHllType_HLL_4, TgtHllType_HLL_6)
-	checkCopyAs(t, TgtHllType_HLL_4, TgtHllType_HLL_8)
-	checkCopyAs(t, TgtHllType_HLL_6, TgtHllType_HLL_4)
-	checkCopyAs(t, TgtHllType_HLL_6, TgtHllType_HLL_6)
-	checkCopyAs(t, TgtHllType_HLL_6, TgtHllType_HLL_8)
-	checkCopyAs(t, TgtHllType_HLL_8, TgtHllType_HLL_4)
-	checkCopyAs(t, TgtHllType_HLL_8, TgtHllType_HLL_6)
-	checkCopyAs(t, TgtHllType_HLL_8, TgtHllType_HLL_8)
+	checkCopyAs(t, TgtHllTypeHll4, TgtHllTypeHll4)
+	checkCopyAs(t, TgtHllTypeHll4, TgtHllTypeHll6)
+	checkCopyAs(t, TgtHllTypeHll4, TgtHllTypeHll8)
+	checkCopyAs(t, TgtHllTypeHll6, TgtHllTypeHll4)
+	checkCopyAs(t, TgtHllTypeHll6, TgtHllTypeHll6)
+	checkCopyAs(t, TgtHllTypeHll6, TgtHllTypeHll8)
+	checkCopyAs(t, TgtHllTypeHll8, TgtHllTypeHll4)
+	checkCopyAs(t, TgtHllTypeHll8, TgtHllTypeHll6)
+	checkCopyAs(t, TgtHllTypeHll8, TgtHllTypeHll8)
 }
 
 func checkCopyAs(t *testing.T, srcType TgtHllType, dstType TgtHllType) {
@@ -154,69 +166,86 @@ func checkCopyAs(t *testing.T, srcType TgtHllType, dstType TgtHllType) {
 	src, err := NewHllSketch(lgK, srcType)
 	assert.NoError(t, err)
 	for i := 0; i < n1; i++ {
-		src.UpdateInt64(int64(i + base))
+		err := src.UpdateInt64(int64(i + base))
+		assert.NoError(t, err)
 	}
-	dst := src.CopyAs(dstType)
-	srcEst := src.GetEstimate()
-	dstEst := dst.GetEstimate()
+	dst, err := src.CopyAs(dstType)
+	assert.NoError(t, err)
+	srcEst, err := src.GetEstimate()
+	assert.NoError(t, err)
+	dstEst, err := dst.GetEstimate()
+	assert.NoError(t, err)
 	assert.Equal(t, srcEst, dstEst)
 
 	for i := n1; i < n2; i++ {
-		src.UpdateInt64(int64(i + base))
+		err := src.UpdateInt64(int64(i + base))
+		assert.NoError(t, err)
 	}
-	dst = src.CopyAs(dstType)
-	srcEst = src.GetEstimate()
-	dstEst = dst.GetEstimate()
+	dst, err = src.CopyAs(dstType)
+	assert.NoError(t, err)
+	srcEst, err = src.GetEstimate()
+	assert.NoError(t, err)
+	dstEst, err = dst.GetEstimate()
+	assert.NoError(t, err)
 	assert.Equal(t, srcEst, dstEst)
 
 	for i := n2; i < n3; i++ {
-		src.UpdateInt64(int64(i + base))
+		err := src.UpdateInt64(int64(i + base))
+		assert.NoError(t, err)
 	}
-	dst = src.CopyAs(dstType)
-	srcEst = src.GetEstimate()
-	dstEst = dst.GetEstimate()
+	dst, err = src.CopyAs(dstType)
+	assert.NoError(t, err)
+	srcEst, err = src.GetEstimate()
+	assert.NoError(t, err)
+	dstEst, err = dst.GetEstimate()
+	assert.NoError(t, err)
 	assert.Equal(t, srcEst, dstEst)
 }
 
 func TestNewHLLDataSketchUint(t *testing.T) {
-	tgts := []TgtHllType{TgtHllType_HLL_4, TgtHllType_HLL_6, TgtHllType_HLL_8}
+	tgts := []TgtHllType{TgtHllTypeHll4, TgtHllTypeHll6, TgtHllTypeHll8}
 	ns := []int{1, 10, 100, 1000, 10000, 100000, 1000000}
 	for _, tgt := range tgts {
 		hll, err := NewHllSketch(11, tgt)
 		assert.NoError(t, err)
 		for _, n := range ns {
 			for i := 0; i < n; i++ {
-				hll.UpdateUInt64(uint64(i))
+				err := hll.UpdateUInt64(uint64(i))
+				assert.NoError(t, err)
 			}
-			est := hll.GetEstimate()
+			est, err := hll.GetEstimate()
+			assert.NoError(t, err)
 			assert.InDelta(t, n, est, float64(n)*0.03)
 		}
 	}
 }
 
 func TestNewHLLDataSketchString(t *testing.T) {
-	tgts := []TgtHllType{TgtHllType_HLL_4, TgtHllType_HLL_6, TgtHllType_HLL_8}
+	tgts := []TgtHllType{TgtHllTypeHll4, TgtHllTypeHll6, TgtHllTypeHll8}
 	ns := []int{1, 10, 100, 1000, 10000, 100000, 1000000}
 	for _, tgt := range tgts {
 		hll, err := NewHllSketch(11, tgt)
 		assert.NoError(t, err)
 		for _, n := range ns {
 			for i := 0; i < n; i++ {
-				hll.UpdateString(strconv.Itoa(i))
+				err := hll.UpdateString(strconv.Itoa(i))
+				assert.NoError(t, err)
 			}
-			est := hll.GetEstimate()
+			est, err := hll.GetEstimate()
+			assert.NoError(t, err)
 			assert.InDelta(t, n, est, float64(n)*0.03)
 		}
 	}
 }
 
 func TestHLLDataSketchT(b *testing.T) {
-	hll, err := NewHllSketch(21, TgtHllType_HLL_4)
+	hll, err := NewHllSketch(21, TgtHllTypeHll4)
 	assert.NoError(b, err)
 	for i := 0; i < 1000000; i++ {
-		hll.UpdateUInt64(uint64(i))
+		_ = hll.UpdateUInt64(uint64(i))
 	}
-	est := hll.GetEstimate()
+	est, err := hll.GetEstimate()
+	assert.NoError(b, err)
 	assert.InDelta(b, 1000000, est, float64(1000000)*0.03)
 
 }
@@ -224,175 +253,177 @@ func TestHLLDataSketchT(b *testing.T) {
 func BenchmarkHLLDataSketch(b *testing.B) {
 	// HLL uint64 BenchMark
 	b.Run("lgK4 HLL4 uint", func(b *testing.B) {
-		hll, _ := NewHllSketch(4, TgtHllType_HLL_4)
+		hll, _ := NewHllSketch(4, TgtHllTypeHll4)
 		for i := 0; i < b.N; i++ {
-			hll.UpdateUInt64(uint64(i))
+			_ = hll.UpdateUInt64(uint64(i))
 		}
 	})
 	b.Run("lgK16 HLL4 uint", func(b *testing.B) {
-		hll, _ := NewHllSketch(16, TgtHllType_HLL_4)
+		hll, _ := NewHllSketch(16, TgtHllTypeHll4)
 		for i := 0; i < b.N; i++ {
-			hll.UpdateUInt64(uint64(i))
+			_ = hll.UpdateUInt64(uint64(i))
 		}
 	})
 	b.Run("lgK21 HLL4 uint", func(b *testing.B) {
-		hll, _ := NewHllSketch(21, TgtHllType_HLL_4)
+		hll, _ := NewHllSketch(21, TgtHllTypeHll4)
 		for i := 0; i < b.N; i++ {
-			hll.UpdateUInt64(uint64(i))
+			_ = hll.UpdateUInt64(uint64(i))
 		}
 	})
 
 	b.Run("lgK4 HLL6 uint", func(b *testing.B) {
-		hll, _ := NewHllSketch(11, TgtHllType_HLL_6)
+		hll, _ := NewHllSketch(11, TgtHllTypeHll6)
 		for i := 0; i < b.N; i++ {
-			hll.UpdateUInt64(uint64(i))
+			_ = hll.UpdateUInt64(uint64(i))
 		}
 	})
 	b.Run("lgK16 HLL6 uint", func(b *testing.B) {
-		hll, _ := NewHllSketch(16, TgtHllType_HLL_6)
+		hll, _ := NewHllSketch(16, TgtHllTypeHll6)
 		for i := 0; i < b.N; i++ {
-			hll.UpdateUInt64(uint64(i))
+			_ = hll.UpdateUInt64(uint64(i))
 		}
 	})
 	b.Run("lgK21 HLL6 uint", func(b *testing.B) {
-		hll, _ := NewHllSketch(21, TgtHllType_HLL_6)
+		hll, _ := NewHllSketch(21, TgtHllTypeHll6)
 		for i := 0; i < b.N; i++ {
-			hll.UpdateUInt64(uint64(i))
+			_ = hll.UpdateUInt64(uint64(i))
 		}
 	})
 
 	b.Run("lgK4 HLL8 uint", func(b *testing.B) {
-		hll, _ := NewHllSketch(11, TgtHllType_HLL_8)
+		hll, _ := NewHllSketch(11, TgtHllTypeHll8)
 		for i := 0; i < b.N; i++ {
-			hll.UpdateUInt64(uint64(i))
+			_ = hll.UpdateUInt64(uint64(i))
 		}
 	})
 	b.Run("lgK16 HLL8 uint", func(b *testing.B) {
-		hll, _ := NewHllSketch(16, TgtHllType_HLL_8)
+		hll, _ := NewHllSketch(16, TgtHllTypeHll8)
 		for i := 0; i < b.N; i++ {
-			hll.UpdateUInt64(uint64(i))
+			_ = hll.UpdateUInt64(uint64(i))
 		}
 	})
 	b.Run("lgK21 HLL8 uint", func(b *testing.B) {
-		hll, _ := NewHllSketch(21, TgtHllType_HLL_8)
+		hll, _ := NewHllSketch(21, TgtHllTypeHll8)
 		for i := 0; i < b.N; i++ {
-			hll.UpdateUInt64(uint64(i))
+			_ = hll.UpdateUInt64(uint64(i))
 		}
 	})
 
 	// HLL Slice BenchMark
 	bs := make([]byte, 8)
 	b.Run("lgK4 HLL4 slice", func(b *testing.B) {
-		hll, _ := NewHllSketch(11, TgtHllType_HLL_4)
+		hll, _ := NewHllSketch(11, TgtHllTypeHll4)
 		for i := 0; i < b.N; i++ {
 			binary.LittleEndian.PutUint64(bs, uint64(i))
-			hll.UpdateSlice(bs)
+			_ = hll.UpdateSlice(bs)
 		}
 	})
 	b.Run("lgK16 HLL4 slice", func(b *testing.B) {
-		hll, _ := NewHllSketch(16, TgtHllType_HLL_4)
+		hll, _ := NewHllSketch(16, TgtHllTypeHll4)
 		for i := 0; i < b.N; i++ {
 			binary.LittleEndian.PutUint64(bs, uint64(i))
-			hll.UpdateSlice(bs)
+			_ = hll.UpdateSlice(bs)
 		}
 	})
 	b.Run("lgK21 HLL4 slice", func(b *testing.B) {
-		hll, _ := NewHllSketch(21, TgtHllType_HLL_4)
+		hll, _ := NewHllSketch(21, TgtHllTypeHll4)
 		for i := 0; i < b.N; i++ {
 			binary.LittleEndian.PutUint64(bs, uint64(i))
-			hll.UpdateSlice(bs)
+			_ = hll.UpdateSlice(bs)
 		}
 	})
 
 	b.Run("lgK4 HLL6 slice", func(b *testing.B) {
-		hll, _ := NewHllSketch(11, TgtHllType_HLL_6)
+		hll, _ := NewHllSketch(11, TgtHllTypeHll6)
 		for i := 0; i < b.N; i++ {
 			binary.LittleEndian.PutUint64(bs, uint64(i))
-			hll.UpdateSlice(bs)
+			_ = hll.UpdateSlice(bs)
 		}
 	})
 	b.Run("lgK16 HLL6 slice", func(b *testing.B) {
-		hll, _ := NewHllSketch(16, TgtHllType_HLL_6)
+		hll, _ := NewHllSketch(16, TgtHllTypeHll6)
 		for i := 0; i < b.N; i++ {
 			binary.LittleEndian.PutUint64(bs, uint64(i))
-			hll.UpdateSlice(bs)
+			_ = hll.UpdateSlice(bs)
 		}
 	})
 	b.Run("lgK21 HLL6 slice", func(b *testing.B) {
-		hll, _ := NewHllSketch(21, TgtHllType_HLL_6)
+		hll, _ := NewHllSketch(21, TgtHllTypeHll6)
 		for i := 0; i < b.N; i++ {
 			binary.LittleEndian.PutUint64(bs, uint64(i))
-			hll.UpdateSlice(bs)
+			_ = hll.UpdateSlice(bs)
 		}
 	})
 
 	b.Run("lgK4 HLL8 slice", func(b *testing.B) {
-		hll, _ := NewHllSketch(11, TgtHllType_HLL_8)
+		hll, _ := NewHllSketch(11, TgtHllTypeHll8)
 		for i := 0; i < b.N; i++ {
 			binary.LittleEndian.PutUint64(bs, uint64(i))
-			hll.UpdateSlice(bs)
+			_ = hll.UpdateSlice(bs)
 		}
 	})
 	b.Run("lgK16 HLL8 slice", func(b *testing.B) {
-		hll, _ := NewHllSketch(16, TgtHllType_HLL_8)
+		hll, _ := NewHllSketch(16, TgtHllTypeHll8)
 		for i := 0; i < b.N; i++ {
 			binary.LittleEndian.PutUint64(bs, uint64(i))
-			hll.UpdateSlice(bs)
+			_ = hll.UpdateSlice(bs)
 		}
 	})
 	b.Run("lgK21 HLL8 slice", func(b *testing.B) {
-		hll, _ := NewHllSketch(21, TgtHllType_HLL_8)
+		hll, _ := NewHllSketch(21, TgtHllTypeHll8)
 		for i := 0; i < b.N; i++ {
 			binary.LittleEndian.PutUint64(bs, uint64(i))
-			hll.UpdateSlice(bs)
+			_ = hll.UpdateSlice(bs)
 		}
 	})
 
 	// Union benchmark
 	b.Run("lgK4 HLL8 union", func(b *testing.B) {
-		hll, _ := NewHllSketch(4, TgtHllType_HLL_8)
+		hll, _ := NewHllSketch(4, TgtHllTypeHll8)
 		union, _ := NewUnion(4)
 		for i := 0; i < b.N; i++ {
-			hll.UpdateSlice(bs)
-			union.UpdateSketch(hll)
+			_ = hll.UpdateSlice(bs)
+			_ = union.UpdateSketch(hll)
 		}
 	})
 	b.Run("lgK16 HLL8 union", func(b *testing.B) {
-		hll, _ := NewHllSketch(16, TgtHllType_HLL_8)
+		hll, _ := NewHllSketch(16, TgtHllTypeHll8)
 		union, _ := NewUnion(16)
 		for i := 0; i < b.N; i++ {
-			hll.UpdateSlice(bs)
-			union.UpdateSketch(hll)
+			_ = hll.UpdateSlice(bs)
+			_ = union.UpdateSketch(hll)
 		}
 	})
 	b.Run("lgK21 HLL8 union", func(b *testing.B) {
-		hll, _ := NewHllSketch(21, TgtHllType_HLL_8)
+		hll, _ := NewHllSketch(21, TgtHllTypeHll8)
 		union, _ := NewUnion(21)
 		for i := 0; i < b.N; i++ {
-			hll.UpdateSlice(bs)
-			union.UpdateSketch(hll)
+			_ = hll.UpdateSlice(bs)
+			_ = union.UpdateSketch(hll)
 		}
 	})
 
 }
 
 func BenchmarkHLLDataSketchWithEstimate(b *testing.B) {
-	hll, err := NewHllSketch(11, TgtHllType_HLL_8)
+	hll, err := NewHllSketch(11, TgtHllTypeHll8)
 	assert.NoError(b, err)
 	for i := 0; i < b.N; i++ {
-		hll.UpdateString(strconv.Itoa(i))
+		_ = hll.UpdateString(strconv.Itoa(i))
 	}
-	est := hll.GetEstimate()
-
+	est, err := hll.GetEstimate()
+	assert.NoError(b, err)
 	estimate := int64(est)
 	fmt.Printf("Estimated cardinality: %d (true: %d) (error: %f)\n ", estimate, b.N, float64(int64(b.N)-estimate)*100/float64(b.N))
 }
 
 // Test the hard case for (shiftedNewValue >= AUX_TOKEN) && (rawStoredOldNibble = AUX_TOKEN)
 func TestHLL4RawStoredOldNibbleAndShiftedNewValueAuxToken(t *testing.T) {
-	hll, _ := NewHllSketch(21, TgtHllType_HLL_4)
+	hll, _ := NewHllSketch(21, TgtHllTypeHll4)
 	for i := uint64(0); i < 29197004; i++ {
-		hll.UpdateUInt64(i)
+		err := hll.UpdateUInt64(i)
+		assert.NoError(t, err)
 	}
-	hll.UpdateUInt64(29197004)
+	err := hll.UpdateUInt64(29197004)
+	assert.NoError(t, err)
 }

--- a/hll/hll_utils.go
+++ b/hll/hll_utils.go
@@ -57,16 +57,16 @@ type TgtHllType int
 type curMode int
 
 const (
-	curMode_LIST curMode = 0
-	curMode_SET  curMode = 1
-	curMode_HLL  curMode = 2
+	curModeList curMode = 0
+	curModeSet  curMode = 1
+	curModeHll  curMode = 2
 )
 
 const (
-	TgtHllType_HLL_4   TgtHllType = 0
-	TgtHllType_HLL_6   TgtHllType = 1
-	TgtHllType_HLL_8   TgtHllType = 2
-	TgtHllType_DEFAULT            = TgtHllType_HLL_4
+	TgtHllTypeHll4    TgtHllType = 0
+	TgtHllTypeHll6    TgtHllType = 1
+	TgtHllTypeHll8    TgtHllType = 2
+	TgtHllTypeDefault            = TgtHllTypeHll4
 )
 
 var (
@@ -79,7 +79,7 @@ var (
 	}
 )
 
-// CheckLgK checks the given lgK and returns it if it is valid and panics otherwise.
+// CheckLgK checks the given lgK and returns it if it is valid and return an error otherwise.
 func checkLgK(lgK int) (int, error) {
 	if lgK >= minLogK && lgK <= maxLogK {
 		return lgK, nil
@@ -115,7 +115,7 @@ func checkNumStdDev(numStdDev int) error {
 	return nil
 }
 
-// checkPreamble checks the given preamble and returns the curMode if it is valid and panics otherwise.
+// checkPreamble checks the given preamble and returns the curMode if it is valid and return an error otherwise.
 func checkPreamble(preamble []byte) (curMode, error) {
 	if len(preamble) == 0 {
 		return 0, fmt.Errorf("preamble cannot be nil or empty")
@@ -128,7 +128,7 @@ func checkPreamble(preamble []byte) (curMode, error) {
 	famId := extractFamilyID(preamble)
 	curMode := extractCurMode(preamble)
 
-	if famId != common.Family_HLL_ID {
+	if famId != common.FamilyHllId {
 		return 0, fmt.Errorf("possible Corruption: Invalid Family: %d", famId)
 	}
 	if serVer != 1 {
@@ -139,15 +139,15 @@ func checkPreamble(preamble []byte) (curMode, error) {
 		return 0, fmt.Errorf("possible Corruption: Invalid Preamble Ints: %d", preInts)
 	}
 
-	if curMode == curMode_LIST && preInts != listPreInts {
+	if curMode == curModeList && preInts != listPreInts {
 		return 0, fmt.Errorf("possible Corruption: Invalid Preamble Ints: %d", preInts)
 	}
 
-	if curMode == curMode_SET && preInts != hashSetPreInts {
+	if curMode == curModeSet && preInts != hashSetPreInts {
 		return 0, fmt.Errorf("possible Corruption: Invalid Preamble Ints: %d", preInts)
 	}
 
-	if curMode == curMode_HLL && preInts != hllPreInts {
+	if curMode == curModeHll && preInts != hllPreInts {
 		return 0, fmt.Errorf("possible Corruption: Invalid Preamble Ints: %d", preInts)
 	}
 
@@ -156,10 +156,10 @@ func checkPreamble(preamble []byte) (curMode, error) {
 
 func getMaxUpdatableSerializationBytes(lgConfigK int, tgtHllType TgtHllType) int {
 	var arrBytes int
-	if tgtHllType == TgtHllType_HLL_4 {
+	if tgtHllType == TgtHllTypeHll4 {
 		auxBytes := 4 << lgAuxArrInts[lgConfigK]
 		arrBytes = (1 << (lgConfigK - 1)) + auxBytes
-	} else if tgtHllType == TgtHllType_HLL_6 {
+	} else if tgtHllType == TgtHllTypeHll6 {
 		numSlots := 1 << lgConfigK
 		arrBytes = ((numSlots * 3) >> 2) + 1
 	} else {

--- a/hll/pair_iterator.go
+++ b/hll/pair_iterator.go
@@ -21,9 +21,9 @@ type pairIterator interface {
 	nextValid() bool
 	nextAll() bool
 	getIndex() int
-	getPair() int
+	getPair() (int, error)
 	getKey() int
-	getValue() int
+	getValue() (int, error)
 	getSlot() int
 }
 
@@ -51,8 +51,8 @@ func newIntArrayPairIterator(array []int, lgConfigK int) pairIterator {
 
 // getPair returns the current key, value pair as a single int where the key is the lower 26 bits
 // and the value is in the upper 6 bits.
-func (i *intArrayPairIterator) getPair() int {
-	return i.pair
+func (i *intArrayPairIterator) getPair() (int, error) {
+	return i.pair, nil
 }
 
 // nextValid returns true at the next pair where getKey() and getValue() are valid.
@@ -86,8 +86,8 @@ func (i *intArrayPairIterator) getKey() int {
 }
 
 // getValue returns the value of the pair.
-func (i *intArrayPairIterator) getValue() int {
-	return getPairValue(i.pair)
+func (i *intArrayPairIterator) getValue() (int, error) {
+	return getPairValue(i.pair), nil
 }
 
 func (i *intArrayPairIterator) getSlot() int {

--- a/hll/preamble_utils.go
+++ b/hll/preamble_utils.go
@@ -163,26 +163,29 @@ func extractAuxCount(byteArr []byte) int {
 	return int(binary.LittleEndian.Uint32(byteArr[auxCountInt : auxCountInt+4]))
 }
 
-func computeLgArr(byteArr []byte, couponCount int, lgConfigK int) int {
+func computeLgArr(byteArr []byte, couponCount int, lgConfigK int) (int, error) {
 	//value is missing, recompute
 	curMode := extractCurMode(byteArr)
-	if curMode == curMode_LIST {
-		return lgInitListSize
+	if curMode == curModeList {
+		return lgInitListSize, nil
 	}
 	ceilPwr2 := common.CeilPowerOf2(couponCount)
 	if (resizeDenom * couponCount) > (resizeNumber * ceilPwr2) {
 		ceilPwr2 <<= 1
 	}
-	if curMode == curMode_SET {
-		return max(lgInitSetSize, common.ExactLog2OfLong(uint64(ceilPwr2)))
+	if curMode == curModeSet {
+		v, err := common.ExactLog2OfLong(uint64(ceilPwr2))
+		return max(lgInitSetSize, v), err
 	}
 	//only used for HLL4
-	return max(lgAuxArrInts[lgConfigK], common.ExactLog2OfLong(uint64(ceilPwr2)))
+	v, err := common.ExactLog2OfLong(uint64(ceilPwr2))
+	return max(lgAuxArrInts[lgConfigK], v), err
 
 }
 
-func insertAuxCount(byteArr []byte, auxCount int) {
+func insertAuxCount(byteArr []byte, auxCount int) error {
 	binary.LittleEndian.PutUint32(byteArr[auxCountInt:auxCountInt+4], uint32(auxCount))
+	return nil
 }
 
 func insertListCount(byteArr []byte, listCnt int) {

--- a/hll/union.go
+++ b/hll/union.go
@@ -307,7 +307,7 @@ func checkRebuildCurMinNumKxQ(sketch HllSketch) error {
 				if err != nil {
 					return err
 				}
-				kxq0 += inv - -1.0
+				kxq0 += inv - 1.0
 			} else {
 				inv, err := common.InvPow2(v)
 				if err != nil {

--- a/hll/union.go
+++ b/hll/union.go
@@ -18,6 +18,7 @@
 package hll
 
 import (
+	"fmt"
 	"github.com/apache/datasketches-go/common"
 )
 
@@ -27,7 +28,7 @@ type Union interface {
 	configuredSketch
 	toSliceSketch
 	privatelyUpdatable
-	UpdateSketch(sketch HllSketch)
+	UpdateSketch(sketch HllSketch) error
 	GetResult(tgtHllType TgtHllType) (HllSketch, error)
 }
 
@@ -36,7 +37,7 @@ type unionImpl struct {
 	gadget HllSketch
 }
 
-func (u *unionImpl) GetHipEstimate() float64 {
+func (u *unionImpl) GetHipEstimate() (float64, error) {
 	return u.gadget.GetHipEstimate()
 }
 
@@ -48,13 +49,13 @@ func (u *unionImpl) GetLowerBound(numStdDev int) (float64, error) {
 	return u.gadget.GetLowerBound(numStdDev)
 }
 
-func (u *unionImpl) couponUpdate(coupon int) hllSketchBase {
+func (u *unionImpl) couponUpdate(coupon int) (hllSketchBase, error) {
 	if coupon == empty {
-		return u.gadget.(*hllSketchImpl).sketch
+		return u.gadget.(*hllSketchImpl).sketch, nil
 	}
-	sk := u.gadget.couponUpdate(coupon)
+	sk, err := u.gadget.couponUpdate(coupon)
 	u.gadget.(*hllSketchImpl).sketch = sk
-	return sk
+	return sk, err
 }
 
 func (u *unionImpl) GetResult(tgtHllType TgtHllType) (HllSketch, error) {
@@ -62,7 +63,7 @@ func (u *unionImpl) GetResult(tgtHllType TgtHllType) (HllSketch, error) {
 	if err != nil {
 		return nil, err
 	}
-	return u.gadget.CopyAs(tgtHllType), nil
+	return u.gadget.CopyAs(tgtHllType)
 }
 
 func NewUnionWithDefault() (Union, error) {
@@ -70,7 +71,7 @@ func NewUnionWithDefault() (Union, error) {
 }
 
 func NewUnion(lgMaxK int) (Union, error) {
-	sk, err := NewHllSketch(lgMaxK, TgtHllType_HLL_8)
+	sk, err := NewHllSketch(lgMaxK, TgtHllTypeHll8)
 	if err != nil {
 		return nil, err
 	}
@@ -93,37 +94,41 @@ func DeserializeUnion(byteArray []byte) (Union, error) {
 	if err != nil {
 		return nil, err
 	}
-	union.UpdateSketch(sk)
-	return union, nil
+	err = union.UpdateSketch(sk)
+	return union, err
 }
 
-func (u *unionImpl) GetCompositeEstimate() float64 {
+func (u *unionImpl) GetCompositeEstimate() (float64, error) {
 	return u.gadget.GetCompositeEstimate()
 }
 
-func (u *unionImpl) GetEstimate() float64 {
+func (u *unionImpl) GetEstimate() (float64, error) {
 	return u.gadget.GetEstimate()
 }
 
-func (u *unionImpl) UpdateUInt64(datum uint64) {
-	u.gadget.UpdateUInt64(datum)
+func (u *unionImpl) UpdateUInt64(datum uint64) error {
+	return u.gadget.UpdateUInt64(datum)
 }
 
-func (u *unionImpl) UpdateInt64(datum int64) {
-	u.gadget.UpdateInt64(datum)
+func (u *unionImpl) UpdateInt64(datum int64) error {
+	return u.gadget.UpdateInt64(datum)
 }
 
-func (u *unionImpl) UpdateSlice(datum []byte) {
-	u.gadget.UpdateSlice(datum)
+func (u *unionImpl) UpdateSlice(datum []byte) error {
+	return u.gadget.UpdateSlice(datum)
 }
 
-func (u *unionImpl) UpdateString(datum string) {
-	u.gadget.UpdateString(datum)
+func (u *unionImpl) UpdateString(datum string) error {
+	return u.gadget.UpdateString(datum)
 }
 
-func (u *unionImpl) UpdateSketch(sketch HllSketch) {
-	un := u.unionImpl(sketch)
+func (u *unionImpl) UpdateSketch(sketch HllSketch) error {
+	un, err := u.unionImpl(sketch)
+	if err != nil {
+		return err
+	}
 	u.gadget.(*hllSketchImpl).sketch = un
+	return nil
 }
 
 func (u *unionImpl) GetLgConfigK() int {
@@ -166,35 +171,35 @@ func (u *unionImpl) Reset() error {
 	return u.gadget.Reset()
 }
 
-func (u *unionImpl) unionImpl(source HllSketch) hllSketchBase {
-	if u.gadget.GetTgtHllType() != TgtHllType_HLL_8 {
-		panic("gadget must be HLL_8")
+func (u *unionImpl) unionImpl(source HllSketch) (hllSketchBase, error) {
+	if u.gadget.GetTgtHllType() != TgtHllTypeHll8 {
+		return nil, fmt.Errorf("gadget must be HLL_8")
 	}
 	if source == nil || source.IsEmpty() {
-		return u.gadget.(*hllSketchImpl).sketch
+		return u.gadget.(*hllSketchImpl).sketch, nil
 	}
 
 	gadgetC := u.gadget.(*hllSketchImpl)
 	sourceC := source.(*hllSketchImpl)
 
 	srcMode := sourceC.sketch.GetCurMode()
-	if srcMode == curMode_LIST {
-		sourceC.mergeTo(u.gadget)
-		return u.gadget.(*hllSketchImpl).sketch
+	if srcMode == curModeList {
+		err := sourceC.mergeTo(u.gadget)
+		return u.gadget.(*hllSketchImpl).sketch, err
 	}
 
 	srcLgK := source.GetLgConfigK()
 	gdgtLgK := u.gadget.GetLgConfigK()
 	gdgtEmpty := u.gadget.IsEmpty()
 
-	if srcMode == curMode_SET {
+	if srcMode == curModeSet {
 		if gdgtEmpty && srcLgK == gdgtLgK {
-			un := sourceC.CopyAs(TgtHllType_HLL_8)
+			un, err := sourceC.CopyAs(TgtHllTypeHll8)
 			gadgetC.sketch = un.(*hllSketchImpl).sketch
-			return gadgetC.sketch
+			return gadgetC.sketch, err
 		}
-		sourceC.mergeTo(u.gadget)
-		return gadgetC.sketch
+		err := sourceC.mergeTo(u.gadget)
+		return gadgetC.sketch, err
 	}
 
 	// Hereafter, the source is in HLL mode.
@@ -228,42 +233,51 @@ func (u *unionImpl) unionImpl(source HllSketch) hllSketchBase {
 		// case 10: src <= max, src <  gdt, gdtSET,  gdtHeap
 		{
 			// Action: copy src, reverse merge w/autofold, ooof=src
-			srcHll8 := sourceC.CopyAs(TgtHllType_HLL_8)
-			gadgetC.mergeTo(srcHll8.(*hllSketchImpl))
-			return srcHll8.(*hllSketchImpl).sketch
+			srcHll8, err := sourceC.CopyAs(TgtHllTypeHll8)
+			if err != nil {
+				return nil, err
+			}
+			err = gadgetC.mergeTo(srcHll8.(*hllSketchImpl))
+			return srcHll8.(*hllSketchImpl).sketch, err
 		}
 	case 16, 18:
 		// case 16: src >  max, src >= gdt, gdtList, gdtHeap
 		// case 18: src >  max, src >= gdt, gdtSet,  gdtHeap
 		{ //Action: downsample src to MaxLgK, reverse merge w/autofold, ooof=src
-			panic("not implemented")
+			return nil, fmt.Errorf("not implemented cas 16,18")
 		}
 	case 4, 20:
 		// case 4: src <= max, src >= gdt, gdtHLL, gdtHeap
 		// case 20: src >  max, src >= gdt, gdtHLL, gdtHeap
 		{ //Action: forward HLL merge w/autofold, ooof=True
 			//merge src(Hll4,6,8,heap/mem,Mode=HLL) -> gdt(Hll8,heap,Mode=HLL)
-			mergeHlltoHLLmode(source, u.gadget, srcLgK, gdgtLgK)
+			err := mergeHlltoHLLmode(source, u.gadget, srcLgK, gdgtLgK)
+			if err != nil {
+				return nil, err
+			}
 			u.gadget.(*hllSketchImpl).sketch.putOutOfOrder(true)
-			return u.gadget.(*hllSketchImpl).sketch
+			return u.gadget.(*hllSketchImpl).sketch, nil
 		}
 	case 12: //src <= max, src <  gdt, gdtHLL, gdtHeap
 		{ //Action: downsample gdt to srcLgK, forward HLL merge w/autofold, ooof=True
-			panic("not implemented")
+			return nil, fmt.Errorf("not implemented case 12")
 		}
 	case 6, 14:
 		// case 6: src <= max, src >= gdt, gdtEmpty, gdtHeap
 		// case 14: src <= max, src <  gdt, gdtEmpty, gdtHeap
 		{ //Action: copy src, replace gdt, ooof=src
-			srcHll8 := sourceC.CopyAs(TgtHllType_HLL_8)
-			return srcHll8.(*hllSketchImpl).sketch
+			srcHll8, err := sourceC.CopyAs(TgtHllTypeHll8)
+			if err != nil {
+				return nil, err
+			}
+			return srcHll8.(*hllSketchImpl).sketch, nil
 		}
 	case 22: //src >  max, src >= gdt, gdtEmpty, gdtHeap
 		{ //Action: downsample src to lgMaxK, replace gdt, ooof=src
-			panic("not implemented")
+			return nil, fmt.Errorf("not implemented")
 		}
 	default:
-		panic("impossible")
+		return nil, fmt.Errorf("impossible")
 	}
 }
 
@@ -272,7 +286,7 @@ func checkRebuildCurMinNumKxQ(sketch HllSketch) error {
 	curMode := sketch.GetCurMode()
 	tgtHllType := sketch.GetTgtHllType()
 	rebuild := sketchImpl.isRebuildCurMinNumKxQFlag()
-	if !rebuild || curMode != curMode_HLL || tgtHllType != TgtHllType_HLL_8 {
+	if !rebuild || curMode != curModeHll || tgtHllType != TgtHllTypeHll8 {
 		return nil
 	}
 
@@ -283,12 +297,23 @@ func checkRebuildCurMinNumKxQ(sketch HllSketch) error {
 	kxq1 := 0.0
 	itr := sketchArrImpl.iterator()
 	for itr.nextAll() {
-		v := itr.getValue()
+		v, err := itr.getValue()
+		if err != nil {
+			return err
+		}
 		if v > 0 {
 			if v < 32 {
-				kxq0 += common.InvPow2(v) - 1.0
+				inv, err := common.InvPow2(v)
+				if err != nil {
+					return err
+				}
+				kxq0 += inv - -1.0
 			} else {
-				kxq1 += common.InvPow2(v) - 1.0
+				inv, err := common.InvPow2(v)
+				if err != nil {
+					return err
+				}
+				kxq1 += inv - 1.0
 			}
 		}
 		if v > curMin {
@@ -311,12 +336,12 @@ func checkRebuildCurMinNumKxQ(sketch HllSketch) error {
 	return nil
 }
 
-func mergeHlltoHLLmode(src HllSketch, tgt HllSketch, srcLgK int, tgtLgK int) {
+func mergeHlltoHLLmode(src HllSketch, tgt HllSketch, srcLgK int, tgtLgK int) error {
 	sw := 0
 	if srcLgK > tgtLgK {
 		sw |= 4
 	}
-	if src.GetTgtHllType() != TgtHllType_HLL_8 {
+	if src.GetTgtHllType() != TgtHllTypeHll8 {
 		sw |= 8
 	}
 	srcK := 1 << srcLgK
@@ -335,7 +360,7 @@ func mergeHlltoHLLmode(src HllSketch, tgt HllSketch, srcLgK int, tgtLgK int) {
 	case 8, 9: //!HLL_8, srcLgK=tgtLgK, src=heap, tgt=heap/mem
 		{
 			tgtAbsHllArr := tgt.(*hllSketchImpl).sketch.(*hll8ArrayImpl)
-			if src.GetTgtHllType() == TgtHllType_HLL_4 {
+			if src.GetTgtHllType() == TgtHllTypeHll4 {
 				src4 := src.(*hllSketchImpl).sketch.(*hll4ArrayImpl)
 				auxHashMap := src4.auxHashMap
 				curMin := src4.curMin
@@ -346,7 +371,10 @@ func mergeHlltoHLLmode(src HllSketch, tgt HllSketch, srcLgK int, tgtLgK int) {
 					i++
 					value := uint(b) & loNibbleMask
 					if value == auxToken {
-						v := auxHashMap.mustFindValueFor(j)
+						v, err := auxHashMap.mustFindValueFor(j)
+						if err != nil {
+							return err
+						}
 						tgtAbsHllArr.updateSlotNoKxQ(j, v)
 					} else {
 						tgtAbsHllArr.updateSlotNoKxQ(j, int(value)+curMin)
@@ -354,7 +382,10 @@ func mergeHlltoHLLmode(src HllSketch, tgt HllSketch, srcLgK int, tgtLgK int) {
 					j++
 					value = uint(b) >> 4
 					if value == auxToken {
-						v := auxHashMap.mustFindValueFor(j)
+						v, err := auxHashMap.mustFindValueFor(j)
+						if err != nil {
+							return err
+						}
 						tgtAbsHllArr.updateSlotNoKxQ(j, v)
 					} else {
 						tgtAbsHllArr.updateSlotNoKxQ(j, int(value)+curMin)
@@ -389,7 +420,8 @@ func mergeHlltoHLLmode(src HllSketch, tgt HllSketch, srcLgK int, tgtLgK int) {
 		}
 		// TODO continue implementing
 	default:
-		panic("not implemented")
+		return fmt.Errorf("not implemented")
 	}
 	tgt.(*hllSketchImpl).sketch.putRebuildCurMinNumKxQFlag(true)
+	return nil
 }

--- a/thetacommon/theta_utils.go
+++ b/thetacommon/theta_utils.go
@@ -18,5 +18,5 @@
 package thetacommon
 
 const (
-	DEFAULT_UPDATE_SEED = uint32(9001)
+	DefaultUpdateSeed = uint32(9001)
 )


### PR DESCRIPTION
Given there is no reasonable way to validate the correctness of the synopsis upon deserialisation, and that incorrect input would surface as error later on during mutation or estimation, prefer bubbling up the error instead of calling panics.

This has negligible impact on performance, and is considered better practice.

Go does not have a concept of exception (instead there are error returns and panics).
Panics are bad practices, especially in libs, as they can easily halt the program altogether.

This also include a pass on Go style/lint for various variable names


```
pkg: github.com/apache/datasketches-go/hll
                                  │ before.bench │       after.bench       │
                                  │         sec/op         │   sec/op     vs base               │
HLLDataSketch/lgK4_HLL4_uint-10                13.05n ± 1%   13.37n ± 1%  +2.37% (p=0.000 n=10)
HLLDataSketch/lgK16_HLL4_uint-10               13.33n ± 2%   13.54n ± 1%  +1.58% (p=0.014 n=10)
HLLDataSketch/lgK21_HLL4_uint-10               19.68n ± 4%   18.96n ± 1%  -3.66% (p=0.000 n=10)
HLLDataSketch/lgK4_HLL6_uint-10                13.68n ± 1%   13.54n ± 1%  -1.02% (p=0.040 n=10)
HLLDataSketch/lgK16_HLL6_uint-10               13.88n ± 1%   13.56n ± 1%  -2.27% (p=0.000 n=10)
HLLDataSketch/lgK21_HLL6_uint-10               20.04n ± 4%   18.55n ± 0%  -7.41% (p=0.000 n=10)
HLLDataSketch/lgK4_HLL8_uint-10                12.81n ± 1%   12.60n ± 1%  -1.68% (p=0.000 n=10)
HLLDataSketch/lgK16_HLL8_uint-10               12.86n ± 1%   12.67n ± 1%  -1.48% (p=0.000 n=10)
HLLDataSketch/lgK21_HLL8_uint-10               19.01n ± 3%   17.34n ± 1%  -8.76% (p=0.000 n=10)
HLLDataSketch/lgK4_HLL4_slice-10               13.55n ± 0%   13.44n ± 0%  -0.77% (p=0.000 n=10)
HLLDataSketch/lgK16_HLL4_slice-10              13.73n ± 1%   13.67n ± 1%       ~ (p=0.100 n=10)
HLLDataSketch/lgK21_HLL4_slice-10              19.23n ± 5%   19.09n ± 0%  -0.73% (p=0.011 n=10)
HLLDataSketch/lgK4_HLL6_slice-10               13.49n ± 1%   13.57n ± 0%  +0.56% (p=0.008 n=10)
HLLDataSketch/lgK16_HLL6_slice-10              13.62n ± 0%   13.77n ± 1%  +1.10% (p=0.000 n=10)
HLLDataSketch/lgK21_HLL6_slice-10              18.88n ± 9%   18.85n ± 1%       ~ (p=0.469 n=10)
HLLDataSketch/lgK4_HLL8_slice-10               12.69n ± 0%   12.77n ± 1%  +0.63% (p=0.007 n=10)
HLLDataSketch/lgK16_HLL8_slice-10              12.78n ± 0%   12.88n ± 1%  +0.78% (p=0.000 n=10)
HLLDataSketch/lgK21_HLL8_slice-10              17.58n ± 9%   17.69n ± 1%       ~ (p=0.952 n=10)
HLLDataSketch/lgK4_HLL8_union-10               25.84n ± 1%   26.76n ± 1%  +3.56% (p=0.000 n=10)
HLLDataSketch/lgK16_HLL8_union-10              25.94n ± 1%   26.60n ± 1%  +2.54% (p=0.000 n=10)
HLLDataSketch/lgK21_HLL8_union-10              25.96n ± 1%   26.50n ± 1%  +2.08% (p=0.000 n=10)
geomean                                        16.20n        16.10n       -0.64%

```