### PR TITLE
Switch Murmur3 to faster implementation

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,8 +5,8 @@ go 1.21
 toolchain go1.21.1
 
 require (
-	github.com/spaolacci/murmur3 v1.1.0
 	github.com/stretchr/testify v1.8.4
+	github.com/twmb/murmur3 v1.1.8
 )
 
 require (

--- a/go.sum
+++ b/go.sum
@@ -2,10 +2,10 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
-github.com/spaolacci/murmur3 v1.1.0 h1:7c1g84S4BPRrfL5Xrdp6fOJ206sU9y293DDHaoy0bLI=
-github.com/spaolacci/murmur3 v1.1.0/go.mod h1:JwIasOWyU6f++ZhiEuf87xNszmSA2myDM2Kzu9HwQUA=
 github.com/stretchr/testify v1.8.4 h1:CcVxjf3Q8PM0mHUKJCdn+eZZtm5yQwehR5yeSVQQcUk=
 github.com/stretchr/testify v1.8.4/go.mod h1:sz/lmYIOXD/1dqDmKjjqLyZ2RngseejIcXlSw2iwfAo=
+github.com/twmb/murmur3 v1.1.8 h1:8Yt9taO/WN3l08xErzjeschgZU2QSrwm1kclYq+0aRg=
+github.com/twmb/murmur3 v1.1.8/go.mod h1:Qq/R7NUyOfr65zD+6Q5IHKsJLwP7exErjN6lyyq3OSQ=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+SDo693bJlVdllGtEeKM=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=

--- a/hll/hll_sketch.go
+++ b/hll/hll_sketch.go
@@ -24,7 +24,7 @@ import (
 	"unsafe"
 
 	"github.com/apache/datasketches-go/thetacommon"
-	"github.com/spaolacci/murmur3"
+	"github.com/twmb/murmur3"
 )
 
 type HllSketch interface {
@@ -316,5 +316,5 @@ func (h *hllSketchImpl) GetSerializationVersion() int {
 }
 
 func (h *hllSketchImpl) hash(bs []byte) (uint64, uint64) {
-	return murmur3.Sum128WithSeed(bs, thetacommon.DefaultUpdateSeed)
+	return murmur3.SeedSum128(thetacommon.DefaultUpdateSeed, thetacommon.DefaultUpdateSeed, bs)
 }

--- a/thetacommon/theta_utils.go
+++ b/thetacommon/theta_utils.go
@@ -18,5 +18,5 @@
 package thetacommon
 
 const (
-	DefaultUpdateSeed = uint32(9001)
+	DefaultUpdateSeed = uint64(9001)
 )


### PR DESCRIPTION
Switch Murmur3 dependency to https://github.com/twmb/murmur3 as it yield better performance than the current one.

```
pkg: github.com/apache/datasketches-go/hll
                                  │      before.bench      │             after.bench             │
                                  │         sec/op         │   sec/op     vs base                │
HLLDataSketch/lgK4_HLL4_uint-10               13.365n ± 1%   9.237n ± 2%  -30.88% (p=0.000 n=10)
HLLDataSketch/lgK16_HLL4_uint-10              13.535n ± 1%   9.496n ± 1%  -29.84% (p=0.000 n=10)
HLLDataSketch/lgK21_HLL4_uint-10               18.96n ± 1%   13.04n ± 1%  -31.25% (p=0.000 n=10)
HLLDataSketch/lgK4_HLL6_uint-10               13.545n ± 1%   9.361n ± 0%  -30.89% (p=0.000 n=10)
HLLDataSketch/lgK16_HLL6_uint-10              13.560n ± 1%   9.504n ± 1%  -29.91% (p=0.000 n=10)
HLLDataSketch/lgK21_HLL6_uint-10               18.55n ± 0%   12.76n ± 1%  -31.23% (p=0.000 n=10)
HLLDataSketch/lgK4_HLL8_uint-10               12.595n ± 1%   8.440n ± 1%  -32.99% (p=0.000 n=10)
HLLDataSketch/lgK16_HLL8_uint-10              12.670n ± 1%   8.460n ± 1%  -33.23% (p=0.000 n=10)
HLLDataSketch/lgK21_HLL8_uint-10               17.34n ± 1%   11.28n ± 1%  -34.97% (p=0.000 n=10)
HLLDataSketch/lgK4_HLL4_slice-10              13.445n ± 0%   9.716n ± 1%  -27.74% (p=0.000 n=10)
HLLDataSketch/lgK16_HLL4_slice-10             13.670n ± 1%   9.731n ± 1%  -28.82% (p=0.000 n=10)
HLLDataSketch/lgK21_HLL4_slice-10              19.09n ± 0%   13.32n ± 3%  -30.21% (p=0.000 n=10)
HLLDataSketch/lgK4_HLL6_slice-10              13.570n ± 0%   9.803n ± 1%  -27.76% (p=0.000 n=10)
HLLDataSketch/lgK16_HLL6_slice-10             13.770n ± 1%   9.826n ± 0%  -28.64% (p=0.000 n=10)
HLLDataSketch/lgK21_HLL6_slice-10              18.85n ± 1%   12.81n ± 1%  -32.06% (p=0.000 n=10)
HLLDataSketch/lgK4_HLL8_slice-10              12.765n ± 1%   8.835n ± 8%  -30.79% (p=0.000 n=10)
HLLDataSketch/lgK16_HLL8_slice-10             12.880n ± 1%   8.870n ± 1%  -31.13% (p=0.000 n=10)
HLLDataSketch/lgK21_HLL8_slice-10              17.69n ± 1%   11.54n ± 1%  -34.72% (p=0.000 n=10)
HLLDataSketch/lgK4_HLL8_union-10               26.76n ± 1%   22.68n ± 1%  -15.21% (p=0.000 n=10)
HLLDataSketch/lgK16_HLL8_union-10              26.60n ± 1%   22.68n ± 1%  -14.76% (p=0.000 n=10)
HLLDataSketch/lgK21_HLL8_union-10              26.50n ± 1%   22.68n ± 0%  -14.43% (p=0.000 n=10)
geomean                                        16.10n        11.45n       -28.87%
```