### PR TITLE
Generic Frequency Item Sketch

### DIFF
--- a/frequencies/items_sketch.go
+++ b/frequencies/items_sketch.go
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package frequencies
+
+import "github.com/apache/datasketches-go/internal"
+
+type ItemsSketch[C comparable] struct {
+	// Log2 Maximum length of the arrays internal to the hashFn map supported by the data
+	// structure.
+	lgMaxMapSize int
+	// The current number of counters supported by the hashFn map.
+	curMapCap int //the threshold to purge
+	// Tracks the total of decremented counts.
+	offset int64
+	// The sum of all frequencies of the stream so far.
+	streamWeight int64
+	// The maximum number of samples used to compute approximate median of counters when doing
+	// decrement
+	sampleSize int
+	// Hash map mapping stored items to approximate counts
+	hashMap *reversePurgeItemHashMap[C]
+}
+
+// NewItemsSketch constructs a new ItemsSketch with the given parameters.
+// this internal constructor is used when deserializing the sketch.
+//
+//   - lgMaxMapSize, log2 of the physical size of the internal hashFn map managed by this
+//     sketch. The maximum capacity of this internal hashFn map is 0.75 times 2^lgMaxMapSize.
+//     Both the ultimate accuracy and size of this sketch are functions of lgMaxMapSize.
+//   - lgCurMapSize, log2 of the starting (current) physical size of the internal hashFn
+//     map managed by this sketch.
+func NewItemsSketch[C comparable](lgMaxMapSize int, lgCurMapSize int, hasher ItemHasher[C]) (*ItemsSketch[C], error) {
+	lgMaxMapSz := max(lgMaxMapSize, _LG_MIN_MAP_SIZE)
+	lgCurMapSz := max(lgCurMapSize, _LG_MIN_MAP_SIZE)
+	hashMap, err := newReversePurgeItemHashMap[C](1<<lgCurMapSz, hasher)
+	if err != nil {
+		return nil, err
+	}
+	curMapCap := hashMap.getCapacity()
+	maxMapCap := int(float64(uint64(1)<<lgMaxMapSize) * reversePurgeItemHashMapLoadFactor)
+	offset := int64(0)
+	sampleSize := min(_SAMPLE_SIZE, maxMapCap)
+
+	return &ItemsSketch[C]{
+		lgMaxMapSize: lgMaxMapSz,
+		curMapCap:    curMapCap,
+		offset:       offset,
+		sampleSize:   sampleSize,
+		hashMap:      hashMap,
+	}, nil
+}
+
+// NewItemsSketchWithMaxMapSize constructs a new ItemsSketch with the given maxMapSize and the default
+// initialMapSize (8).
+//
+//   - maxMapSize, Determines the physical size of the internal hashFn map managed by this
+//     sketch and must be a power of 2. The maximum capacity of this internal hashFn map is
+//     0.75 times * maxMapSize. Both the ultimate accuracy and size of this sketch are
+//     functions of maxMapSize.
+func NewItemsSketchWithMaxMapSize[C comparable](maxMapSize int, hasher ItemHasher[C]) (*ItemsSketch[C], error) {
+	maxMapSz, err := internal.ExactLog2(maxMapSize)
+	if err != nil {
+		return nil, err
+	}
+	return NewItemsSketch[C](maxMapSz, _LG_MIN_MAP_SIZE, hasher)
+}
+
+// IsEmpty returns true if this sketch is empty.
+func (i *ItemsSketch[C]) IsEmpty() bool {
+	return i.GetNumActiveItems() == 0
+}
+
+// GetNumActiveItems returns the number of active items in the sketch.
+func (i *ItemsSketch[C]) GetNumActiveItems() int {
+	return i.hashMap.numActive
+}
+
+// GetStreamLength returns the sum of the frequencies in the stream seen so far by the sketch.
+func (i *ItemsSketch[C]) GetStreamLength() int64 {
+	return i.streamWeight
+}
+
+// GetLowerBound gets the guaranteed lower bound frequency of the given item, which can never be
+// negative.
+//
+//   - item, the given item.
+func (i *ItemsSketch[C]) GetLowerBound(item C) (int64, error) {
+	return i.hashMap.get(item)
+}
+
+// GetUpperBound gets the guaranteed upper bound frequency of the given item.
+//
+//   - item, the given item.
+func (i *ItemsSketch[C]) GetUpperBound(item C) (int64, error) {
+	// UB = itemCount + offset
+	v, err := i.hashMap.get(item)
+	return v + i.offset, err
+}

--- a/frequencies/items_sketch.go
+++ b/frequencies/items_sketch.go
@@ -24,7 +24,7 @@ import (
 	"sort"
 )
 
-type ItemsSketch[C comparable] struct {
+type FrequencyItemsSketch[C comparable] struct {
 	// Log2 Maximum length of the arrays internal to the hashFn map supported by the data
 	// structure.
 	lgMaxMapSize int
@@ -41,14 +41,14 @@ type ItemsSketch[C comparable] struct {
 	hashMap *reversePurgeItemHashMap[C]
 }
 
-type ItemSketchOp[C comparable] interface {
+type FrequencyItemSketchOp[C comparable] interface {
 	Hash(item C) uint64
 	SerializeOneToSlice(item C) []byte
 	SerializeManyToSlice(item []C) []byte
 	DeserializeManyFromSlice(slc []byte, offset int, length int) []C
 }
 
-// NewItemsSketch constructs a new ItemsSketch with the given parameters.
+// NewFrequencyItemsSketch constructs a new FrequencyItemsSketch with the given parameters.
 // this internal constructor is used when deserializing the sketch.
 //
 //   - lgMaxMapSize, log2 of the physical size of the internal hashFn map managed by this
@@ -56,7 +56,7 @@ type ItemSketchOp[C comparable] interface {
 //     Both the ultimate accuracy and size of this sketch are functions of lgMaxMapSize.
 //   - lgCurMapSize, log2 of the starting (current) physical size of the internal hashFn
 //     map managed by this sketch.
-func NewItemsSketch[C comparable](lgMaxMapSize int, lgCurMapSize int, operations ItemSketchOp[C]) (*ItemsSketch[C], error) {
+func NewFrequencyItemsSketch[C comparable](lgMaxMapSize int, lgCurMapSize int, operations FrequencyItemSketchOp[C]) (*FrequencyItemsSketch[C], error) {
 	lgMaxMapSz := max(lgMaxMapSize, _LG_MIN_MAP_SIZE)
 	lgCurMapSz := max(lgCurMapSize, _LG_MIN_MAP_SIZE)
 	hashMap, err := newReversePurgeItemHashMap[C](1<<lgCurMapSz, operations)
@@ -68,7 +68,7 @@ func NewItemsSketch[C comparable](lgMaxMapSize int, lgCurMapSize int, operations
 	offset := int64(0)
 	sampleSize := min(_SAMPLE_SIZE, maxMapCap)
 
-	return &ItemsSketch[C]{
+	return &FrequencyItemsSketch[C]{
 		lgMaxMapSize: lgMaxMapSz,
 		curMapCap:    curMapCap,
 		offset:       offset,
@@ -77,22 +77,22 @@ func NewItemsSketch[C comparable](lgMaxMapSize int, lgCurMapSize int, operations
 	}, nil
 }
 
-// NewItemsSketchWithMaxMapSize constructs a new ItemsSketch with the given maxMapSize and the default
+// NewFrequencyItemsSketchWithMaxMapSize constructs a new FrequencyItemsSketch with the given maxMapSize and the default
 // initialMapSize (8).
 //
 //   - maxMapSize, Determines the physical size of the internal hashFn map managed by this
 //     sketch and must be a power of 2. The maximum capacity of this internal hashFn map is
 //     0.75 times * maxMapSize. Both the ultimate accuracy and size of this sketch are
 //     functions of maxMapSize.
-func NewItemsSketchWithMaxMapSize[C comparable](maxMapSize int, operations ItemSketchOp[C]) (*ItemsSketch[C], error) {
+func NewFrequencyItemsSketchWithMaxMapSize[C comparable](maxMapSize int, operations FrequencyItemSketchOp[C]) (*FrequencyItemsSketch[C], error) {
 	maxMapSz, err := internal.ExactLog2(maxMapSize)
 	if err != nil {
 		return nil, err
 	}
-	return NewItemsSketch[C](maxMapSz, _LG_MIN_MAP_SIZE, operations)
+	return NewFrequencyItemsSketch[C](maxMapSz, _LG_MIN_MAP_SIZE, operations)
 }
 
-func NewItemsSketchFromSlice[C comparable](slc []byte, operations ItemSketchOp[C]) (*ItemsSketch[C], error) {
+func NewFrequencyItemsSketchFromSlice[C comparable](slc []byte, operations FrequencyItemSketchOp[C]) (*FrequencyItemsSketch[C], error) {
 	pre0, err := checkPreambleSize(slc) //make sure preamble will fit
 	maxPreLongs := internal.FamilyEnum.Frequency.MaxPreLongs
 
@@ -120,7 +120,7 @@ func NewItemsSketchFromSlice[C comparable](slc []byte, operations ItemSketchOp[C
 		return nil, fmt.Errorf("(preLongs == 1) ^ empty == true")
 	}
 	if empty {
-		return NewItemsSketchWithMaxMapSize[C](1<<_LG_MIN_MAP_SIZE, operations)
+		return NewFrequencyItemsSketchWithMaxMapSize[C](1<<_LG_MIN_MAP_SIZE, operations)
 	}
 	// Get full preamble
 	preArr := make([]int64, preLongs)
@@ -128,7 +128,7 @@ func NewItemsSketchFromSlice[C comparable](slc []byte, operations ItemSketchOp[C
 		preArr[j] = int64(binary.LittleEndian.Uint64(slc[j<<3:]))
 	}
 
-	fis, err := NewItemsSketch[C](int(lgMaxMapSize), int(lgCurMapSize), operations)
+	fis, err := NewFrequencyItemsSketch[C](int(lgMaxMapSize), int(lgCurMapSize), operations)
 	if err != nil {
 		return nil, err
 	}
@@ -161,7 +161,7 @@ func NewItemsSketchFromSlice[C comparable](slc []byte, operations ItemSketchOp[C
 	return fis, nil
 }
 
-func (i *ItemsSketch[C]) Reset() error {
+func (i *FrequencyItemsSketch[C]) Reset() error {
 	hashMap, err := newReversePurgeItemHashMap[C](1<<_LG_MIN_MAP_SIZE, i.hashMap.operations)
 	if err != nil {
 		return err
@@ -174,25 +174,25 @@ func (i *ItemsSketch[C]) Reset() error {
 }
 
 // IsEmpty returns true if this sketch is empty.
-func (i *ItemsSketch[C]) IsEmpty() bool {
+func (i *FrequencyItemsSketch[C]) IsEmpty() bool {
 	return i.GetNumActiveItems() == 0
 }
 
 // GetNumActiveItems returns the number of active items in the sketch.
-func (i *ItemsSketch[C]) GetNumActiveItems() int {
+func (i *FrequencyItemsSketch[C]) GetNumActiveItems() int {
 	return i.hashMap.numActive
 }
 
 // GetStreamLength returns the sum of the frequencies in the stream seen so far by the sketch.
-func (i *ItemsSketch[C]) GetStreamLength() int64 {
+func (i *FrequencyItemsSketch[C]) GetStreamLength() int64 {
 	return i.streamWeight
 }
 
-func (i *ItemsSketch[C]) Update(item C) error {
+func (i *FrequencyItemsSketch[C]) Update(item C) error {
 	return i.UpdateMany(item, 1)
 }
 
-func (i *ItemsSketch[C]) UpdateMany(item C, count int) error {
+func (i *FrequencyItemsSketch[C]) UpdateMany(item C, count int) error {
 	if isNil(item) || count == 0 {
 		return nil
 	}
@@ -223,7 +223,7 @@ func (i *ItemsSketch[C]) UpdateMany(item C, count int) error {
 	return nil
 }
 
-func (i *ItemsSketch[C]) GetEstimate(item C) (int64, error) {
+func (i *FrequencyItemsSketch[C]) GetEstimate(item C) (int64, error) {
 	// If item is tracked:
 	// Estimate = itemCount + offset; Otherwise it is 0.
 	v, err := i.hashMap.get(item)
@@ -237,28 +237,28 @@ func (i *ItemsSketch[C]) GetEstimate(item C) (int64, error) {
 // negative.
 //
 //   - item, the given item.
-func (i *ItemsSketch[C]) GetLowerBound(item C) (int64, error) {
+func (i *FrequencyItemsSketch[C]) GetLowerBound(item C) (int64, error) {
 	return i.hashMap.get(item)
 }
 
 // GetUpperBound gets the guaranteed upper bound frequency of the given item.
 //
 //   - item, the given item.
-func (i *ItemsSketch[C]) GetUpperBound(item C) (int64, error) {
+func (i *FrequencyItemsSketch[C]) GetUpperBound(item C) (int64, error) {
 	// UB = itemCount + offset
 	v, err := i.hashMap.get(item)
 	return v + i.offset, err
 }
 
-func (i *ItemsSketch[C]) GetMaximumError() int64 {
+func (i *FrequencyItemsSketch[C]) GetMaximumError() int64 {
 	return i.offset
 }
 
-func (i *ItemsSketch[C]) GetFrequentItems(errorType errorType) ([]*RowItem[C], error) {
+func (i *FrequencyItemsSketch[C]) GetFrequentItems(errorType errorType) ([]*RowItem[C], error) {
 	return i.sortItems(i.GetMaximumError(), errorType)
 }
 
-func (i *ItemsSketch[C]) GetFrequentItemsWithThreshold(threshold int64, errorType errorType) ([]*RowItem[C], error) {
+func (i *FrequencyItemsSketch[C]) GetFrequentItemsWithThreshold(threshold int64, errorType errorType) ([]*RowItem[C], error) {
 	finalThreshold := i.GetMaximumError()
 	if threshold > finalThreshold {
 		finalThreshold = threshold
@@ -266,7 +266,7 @@ func (i *ItemsSketch[C]) GetFrequentItemsWithThreshold(threshold int64, errorTyp
 	return i.sortItems(finalThreshold, errorType)
 }
 
-func (i *ItemsSketch[C]) ToSlice() []byte {
+func (i *FrequencyItemsSketch[C]) ToSlice() []byte {
 	preLongs := 0
 	outBytes := 0
 	empty := i.IsEmpty()
@@ -315,7 +315,7 @@ func (i *ItemsSketch[C]) ToSlice() []byte {
 	return outArr
 }
 
-func (i *ItemsSketch[C]) sortItems(threshold int64, errorType errorType) ([]*RowItem[C], error) {
+func (i *FrequencyItemsSketch[C]) sortItems(threshold int64, errorType errorType) ([]*RowItem[C], error) {
 	rowList := make([]*RowItem[C], 0)
 	iter := i.hashMap.iterator()
 	if errorType == ErrorTypeEnum.NoFalseNegatives {

--- a/frequencies/items_sketch.go
+++ b/frequencies/items_sketch.go
@@ -36,6 +36,10 @@ type ItemsSketch[C comparable] struct {
 	hashMap *reversePurgeItemHashMap[C]
 }
 
+type ItemSketchHasher[C comparable] interface {
+	Hash(item C) uint64
+}
+
 // NewItemsSketch constructs a new ItemsSketch with the given parameters.
 // this internal constructor is used when deserializing the sketch.
 //
@@ -44,7 +48,7 @@ type ItemsSketch[C comparable] struct {
 //     Both the ultimate accuracy and size of this sketch are functions of lgMaxMapSize.
 //   - lgCurMapSize, log2 of the starting (current) physical size of the internal hashFn
 //     map managed by this sketch.
-func NewItemsSketch[C comparable](lgMaxMapSize int, lgCurMapSize int, hasher ItemHasher[C]) (*ItemsSketch[C], error) {
+func NewItemsSketch[C comparable](lgMaxMapSize int, lgCurMapSize int, hasher ItemSketchHasher[C]) (*ItemsSketch[C], error) {
 	lgMaxMapSz := max(lgMaxMapSize, _LG_MIN_MAP_SIZE)
 	lgCurMapSz := max(lgCurMapSize, _LG_MIN_MAP_SIZE)
 	hashMap, err := newReversePurgeItemHashMap[C](1<<lgCurMapSz, hasher)
@@ -72,7 +76,7 @@ func NewItemsSketch[C comparable](lgMaxMapSize int, lgCurMapSize int, hasher Ite
 //     sketch and must be a power of 2. The maximum capacity of this internal hashFn map is
 //     0.75 times * maxMapSize. Both the ultimate accuracy and size of this sketch are
 //     functions of maxMapSize.
-func NewItemsSketchWithMaxMapSize[C comparable](maxMapSize int, hasher ItemHasher[C]) (*ItemsSketch[C], error) {
+func NewItemsSketchWithMaxMapSize[C comparable](maxMapSize int, hasher ItemSketchHasher[C]) (*ItemsSketch[C], error) {
 	maxMapSz, err := internal.ExactLog2(maxMapSize)
 	if err != nil {
 		return nil, err

--- a/frequencies/items_sketch.go
+++ b/frequencies/items_sketch.go
@@ -40,8 +40,10 @@ type ItemsSketch[C comparable] struct {
 	hashMap *reversePurgeItemHashMap[C]
 }
 
-type ItemSketchHasher[C comparable] interface {
+type ItemSketchOp[C comparable] interface {
 	Hash(item C) uint64
+	SerializeOneToSlice(item C) []byte
+	SerializeManyToSlice(item []C) []byte
 }
 
 // NewItemsSketch constructs a new ItemsSketch with the given parameters.
@@ -52,7 +54,7 @@ type ItemSketchHasher[C comparable] interface {
 //     Both the ultimate accuracy and size of this sketch are functions of lgMaxMapSize.
 //   - lgCurMapSize, log2 of the starting (current) physical size of the internal hashFn
 //     map managed by this sketch.
-func NewItemsSketch[C comparable](lgMaxMapSize int, lgCurMapSize int, hasher ItemSketchHasher[C]) (*ItemsSketch[C], error) {
+func NewItemsSketch[C comparable](lgMaxMapSize int, lgCurMapSize int, hasher ItemSketchOp[C]) (*ItemsSketch[C], error) {
 	lgMaxMapSz := max(lgMaxMapSize, _LG_MIN_MAP_SIZE)
 	lgCurMapSz := max(lgCurMapSize, _LG_MIN_MAP_SIZE)
 	hashMap, err := newReversePurgeItemHashMap[C](1<<lgCurMapSz, hasher)
@@ -80,7 +82,7 @@ func NewItemsSketch[C comparable](lgMaxMapSize int, lgCurMapSize int, hasher Ite
 //     sketch and must be a power of 2. The maximum capacity of this internal hashFn map is
 //     0.75 times * maxMapSize. Both the ultimate accuracy and size of this sketch are
 //     functions of maxMapSize.
-func NewItemsSketchWithMaxMapSize[C comparable](maxMapSize int, hasher ItemSketchHasher[C]) (*ItemsSketch[C], error) {
+func NewItemsSketchWithMaxMapSize[C comparable](maxMapSize int, hasher ItemSketchOp[C]) (*ItemsSketch[C], error) {
 	maxMapSz, err := internal.ExactLog2(maxMapSize)
 	if err != nil {
 		return nil, err

--- a/frequencies/items_sketch_test.go
+++ b/frequencies/items_sketch_test.go
@@ -19,6 +19,7 @@ package frequencies
 
 import (
 	"encoding/binary"
+	"strconv"
 	"testing"
 	"unsafe"
 
@@ -326,4 +327,12 @@ func TestSerializeDeserializeUtf8Strings(t *testing.T) {
 	est, err = sketch2.GetEstimate("ddddddddddddddddddddddddddddd")
 	assert.NoError(t, err)
 	assert.Equal(t, est, int64(1))
+}
+
+func TestResize(t *testing.T) {
+	sketch1, err := NewItemsSketchWithMaxMapSize[string](2<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	for i := 0; i < 32; i++ {
+		err = sketch1.UpdateMany(strconv.Itoa(i), i*i)
+		assert.NoError(t, err)
+	}
 }

--- a/frequencies/items_sketch_test.go
+++ b/frequencies/items_sketch_test.go
@@ -548,3 +548,11 @@ func TestItemGetAprioriError(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, apr, eps*10_000)
 }
+
+func BenchmarkItemSketch(b *testing.B) {
+	sketch, err := NewItemsSketch[int64](128, 8, IntItemsSketchOp{})
+	assert.NoError(b, err)
+	for i := 0; i < b.N; i++ {
+		sketch.Update(int64(i))
+	}
+}

--- a/frequencies/items_sketch_test.go
+++ b/frequencies/items_sketch_test.go
@@ -123,7 +123,7 @@ func (h IntItemsSketchOp) DeserializeManyFromSlice(slc []byte, offset int, lengt
 
 func TestEmpty(t *testing.T) {
 	h := StringItemsSketchOp{}
-	sketch, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, h)
+	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, h)
 	assert.NoError(t, err)
 	assert.True(t, sketch.IsEmpty())
 	assert.Equal(t, sketch.GetNumActiveItems(), 0)
@@ -138,7 +138,7 @@ func TestEmpty(t *testing.T) {
 
 func TestNilInput(t *testing.T) {
 	h := StringPointerSketchOp{}
-	sketch, err := NewItemsSketchWithMaxMapSize[*string](1<<_LG_MIN_MAP_SIZE, h)
+	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[*string](1<<_LG_MIN_MAP_SIZE, h)
 	assert.NoError(t, err)
 	err = sketch.Update(nil)
 	assert.NoError(t, err)
@@ -155,7 +155,7 @@ func TestNilInput(t *testing.T) {
 }
 
 func TestOneItem(t *testing.T) {
-	sketch, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
 	assert.NoError(t, err)
 	err = sketch.Update("a")
 	assert.NoError(t, err)
@@ -171,7 +171,7 @@ func TestOneItem(t *testing.T) {
 }
 
 func TestSeveralItem(t *testing.T) {
-	sketch, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
 	assert.NoError(t, err)
 	err = sketch.Update("a")
 	assert.NoError(t, err)
@@ -220,7 +220,7 @@ func TestSeveralItem(t *testing.T) {
 }
 
 func TestEstimationMode(t *testing.T) {
-	sketch, err := NewItemsSketchWithMaxMapSize[int](1<<_LG_MIN_MAP_SIZE, IntItemsSketchOp{})
+	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[int](1<<_LG_MIN_MAP_SIZE, IntItemsSketchOp{})
 	assert.NoError(t, err)
 	err = sketch.UpdateMany(1, 10)
 	assert.NoError(t, err)
@@ -280,10 +280,10 @@ func TestEstimationMode(t *testing.T) {
 }
 
 func TestSerializeStringDeserializeEmpty(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
 	assert.NoError(t, err)
 	bytes := sketch1.ToSlice()
-	sketch2, err := NewItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
+	sketch2, err := NewFrequencyItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
 	assert.NoError(t, err)
 	assert.True(t, sketch2.IsEmpty())
 	assert.Equal(t, sketch2.GetNumActiveItems(), 0)
@@ -291,7 +291,7 @@ func TestSerializeStringDeserializeEmpty(t *testing.T) {
 }
 
 func TestSerializeDeserializeUtf8Strings(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
 	assert.NoError(t, err)
 	err = sketch1.Update("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	assert.NoError(t, err)
@@ -303,7 +303,7 @@ func TestSerializeDeserializeUtf8Strings(t *testing.T) {
 	assert.NoError(t, err)
 
 	bytes := sketch1.ToSlice()
-	sketch2, err := NewItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
+	sketch2, err := NewFrequencyItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
 	assert.NoError(t, err)
 	err = sketch2.Update("bbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
 	assert.NoError(t, err)
@@ -330,7 +330,7 @@ func TestSerializeDeserializeUtf8Strings(t *testing.T) {
 }
 
 func TestResize(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[string](2<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](2<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
 	for i := 0; i < 32; i++ {
 		err = sketch1.UpdateMany(strconv.Itoa(i), i*i)
 		assert.NoError(t, err)

--- a/frequencies/items_sketch_test.go
+++ b/frequencies/items_sketch_test.go
@@ -123,7 +123,7 @@ func (h IntItemsSketchOp) DeserializeManyFromSlice(slc []byte, offset int, lengt
 
 func TestEmpty(t *testing.T) {
 	h := StringItemsSketchOp{}
-	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, h)
+	sketch, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, h)
 	assert.NoError(t, err)
 	assert.True(t, sketch.IsEmpty())
 	assert.Equal(t, sketch.GetNumActiveItems(), 0)
@@ -138,7 +138,7 @@ func TestEmpty(t *testing.T) {
 
 func TestNilInput(t *testing.T) {
 	h := StringPointerSketchOp{}
-	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[*string](1<<_LG_MIN_MAP_SIZE, h)
+	sketch, err := NewItemsSketchWithMaxMapSize[*string](1<<_LG_MIN_MAP_SIZE, h)
 	assert.NoError(t, err)
 	err = sketch.Update(nil)
 	assert.NoError(t, err)
@@ -155,7 +155,7 @@ func TestNilInput(t *testing.T) {
 }
 
 func TestOneItem(t *testing.T) {
-	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
 	assert.NoError(t, err)
 	err = sketch.Update("a")
 	assert.NoError(t, err)
@@ -171,7 +171,7 @@ func TestOneItem(t *testing.T) {
 }
 
 func TestSeveralItem(t *testing.T) {
-	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
 	assert.NoError(t, err)
 	err = sketch.Update("a")
 	assert.NoError(t, err)
@@ -220,7 +220,7 @@ func TestSeveralItem(t *testing.T) {
 }
 
 func TestEstimationMode(t *testing.T) {
-	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[int](1<<_LG_MIN_MAP_SIZE, IntItemsSketchOp{})
+	sketch, err := NewItemsSketchWithMaxMapSize[int](1<<_LG_MIN_MAP_SIZE, IntItemsSketchOp{})
 	assert.NoError(t, err)
 	err = sketch.UpdateMany(1, 10)
 	assert.NoError(t, err)
@@ -280,10 +280,10 @@ func TestEstimationMode(t *testing.T) {
 }
 
 func TestSerializeStringDeserializeEmpty(t *testing.T) {
-	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch1, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
 	assert.NoError(t, err)
 	bytes := sketch1.ToSlice()
-	sketch2, err := NewFrequencyItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
+	sketch2, err := NewItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
 	assert.NoError(t, err)
 	assert.True(t, sketch2.IsEmpty())
 	assert.Equal(t, sketch2.GetNumActiveItems(), 0)
@@ -291,7 +291,7 @@ func TestSerializeStringDeserializeEmpty(t *testing.T) {
 }
 
 func TestSerializeDeserializeUtf8Strings(t *testing.T) {
-	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch1, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
 	assert.NoError(t, err)
 	err = sketch1.Update("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	assert.NoError(t, err)
@@ -303,7 +303,7 @@ func TestSerializeDeserializeUtf8Strings(t *testing.T) {
 	assert.NoError(t, err)
 
 	bytes := sketch1.ToSlice()
-	sketch2, err := NewFrequencyItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
+	sketch2, err := NewItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
 	assert.NoError(t, err)
 	err = sketch2.Update("bbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
 	assert.NoError(t, err)
@@ -330,7 +330,7 @@ func TestSerializeDeserializeUtf8Strings(t *testing.T) {
 }
 
 func TestResize(t *testing.T) {
-	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](2<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch1, err := NewItemsSketchWithMaxMapSize[string](2<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
 	for i := 0; i < 32; i++ {
 		err = sketch1.UpdateMany(strconv.Itoa(i), i*i)
 		assert.NoError(t, err)

--- a/frequencies/iterms_sketch_test.go
+++ b/frequencies/iterms_sketch_test.go
@@ -1,0 +1,28 @@
+package frequencies
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+type StringHasher struct {
+}
+
+func (h StringHasher) Hash(item string) uint64 {
+	return uint64(len(item))
+}
+
+func TestEmpty(t *testing.T) {
+	h := StringHasher{}
+	sketch, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, h)
+	assert.NoError(t, err)
+	assert.True(t, sketch.IsEmpty())
+	assert.Equal(t, sketch.GetNumActiveItems(), 0)
+	assert.Equal(t, sketch.GetStreamLength(), int64(0))
+	lb, err := sketch.GetLowerBound("a")
+	assert.NoError(t, err)
+	assert.Equal(t, lb, int64(0))
+	ub, err := sketch.GetUpperBound("a")
+	assert.NoError(t, err)
+	assert.Equal(t, ub, int64(0))
+}

--- a/frequencies/iterms_sketch_test.go
+++ b/frequencies/iterms_sketch_test.go
@@ -48,3 +48,29 @@ func TestEmpty(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, ub, int64(0))
 }
+
+type StringPointerHasher struct {
+}
+
+func (h StringPointerHasher) Hash(item *string) uint64 {
+	datum := unsafe.Slice(unsafe.StringData(*item), len(*item))
+	return murmur3.SeedSum64(internal.DEFAULT_UPDATE_SEED, datum[:])
+}
+
+func TestNilInput(t *testing.T) {
+	h := StringPointerHasher{}
+	sketch, err := NewItemsSketchWithMaxMapSize[*string](1<<_LG_MIN_MAP_SIZE, h)
+	assert.NoError(t, err)
+	err = sketch.Update(nil)
+	assert.NoError(t, err)
+	assert.True(t, sketch.IsEmpty())
+	assert.Equal(t, sketch.GetNumActiveItems(), 0)
+	assert.Equal(t, sketch.GetStreamLength(), int64(0))
+	lb, err := sketch.GetLowerBound(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, lb, int64(0))
+	ub, err := sketch.GetUpperBound(nil)
+	assert.NoError(t, err)
+	assert.Equal(t, ub, int64(0))
+
+}

--- a/frequencies/iterms_sketch_test.go
+++ b/frequencies/iterms_sketch_test.go
@@ -1,15 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package frequencies
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+	"unsafe"
+
+	"github.com/apache/datasketches-go/internal"
+	"github.com/stretchr/testify/assert"
+	"github.com/twmb/murmur3"
 )
 
 type StringHasher struct {
 }
 
 func (h StringHasher) Hash(item string) uint64 {
-	return uint64(len(item))
+	datum := unsafe.Slice(unsafe.StringData(item), len(item))
+	return murmur3.SeedSum64(internal.DEFAULT_UPDATE_SEED, datum[:])
 }
 
 func TestEmpty(t *testing.T) {

--- a/frequencies/longs_sketch.go
+++ b/frequencies/longs_sketch.go
@@ -497,7 +497,7 @@ func (s *LongsSketch) ToString() (string, error) {
 }
 
 // ToSlice returns a slice representation of this sketch
-func (s *LongsSketch) ToSlice() ([]byte, error) {
+func (s *LongsSketch) ToSlice() []byte {
 	emtpy := s.IsEmpty()
 	activeItems := s.GetNumActiveItems()
 	preLongs := 1
@@ -518,7 +518,7 @@ func (s *LongsSketch) ToSlice() ([]byte, error) {
 	if emtpy {
 		pre0 = insertFlags(_EMPTY_FLAG_MASK, pre0) //Byte 5
 		binary.LittleEndian.PutUint64(outArr, uint64(pre0))
-		return outArr, nil
+		return outArr
 	}
 	pre := int64(0)
 	pre0 = insertFlags(0, pre0) //Byte 5
@@ -533,23 +533,17 @@ func (s *LongsSketch) ToSlice() ([]byte, error) {
 	}
 
 	preBytes := preLongs << 3
-	activeValues, err := s.hashMap.getActiveValues()
-	if err != nil {
-		return nil, err
-	}
+	activeValues := s.hashMap.getActiveValues()
 	for i := 0; i < activeItems; i++ {
 		binary.LittleEndian.PutUint64(outArr[preBytes+(i<<3):], uint64(activeValues[i]))
 	}
 
-	activeKeys, err := s.hashMap.getActiveKeys()
-	if err != nil {
-		return nil, err
-	}
+	activeKeys := s.hashMap.getActiveKeys()
 	for i := 0; i < activeItems; i++ {
 		binary.LittleEndian.PutUint64(outArr[preBytes+((activeItems+i)<<3):], uint64(activeKeys[i]))
 	}
 
-	return outArr, nil
+	return outArr
 }
 
 // Reset resets this sketch to a virgin state.

--- a/frequencies/longs_sketch.go
+++ b/frequencies/longs_sketch.go
@@ -30,10 +30,10 @@ import (
 )
 
 type LongsSketch struct {
-	// Log2 Maximum length of the arrays internal to the hashFn map supported by the data
+	// Log2 Maximum length of the arrays internal to the hash map supported by the data
 	// structure.
 	lgMaxMapSize int
-	// The current number of counters supported by the hashFn map.
+	// The current number of counters supported by the hash map.
 	curMapCap int //the threshold to purge
 	// Tracks the total of decremented counts.
 	offset int64
@@ -52,14 +52,14 @@ const (
 
 // NewLongsSketch returns a new LongsSketch with the given lgMaxMapSize and lgCurMapSize.
 //
-// lgMaxMapSize is the log2 of the physical size of the internal hashFn map managed by this
-// sketch. The maximum capacity of this internal hashFn map is 0.75 times 2^lgMaxMapSize.
+// lgMaxMapSize is the log2 of the physical size of the internal hash map managed by this
+// sketch. The maximum capacity of this internal hash map is 0.75 times 2^lgMaxMapSize.
 // Both the ultimate accuracy and size of this sketch are a function of lgMaxMapSize.
 //
 // lgCurMapSize is the log2 of the starting (current) physical size of the internal hashFn
 // map managed by this sketch.
 func NewLongsSketch(lgMaxMapSize int, lgCurMapSize int) (*LongsSketch, error) {
-	//set initial size of hashFn map
+	//set initial size of hash map
 	lgMaxMapSize = max(lgMaxMapSize, _LG_MIN_MAP_SIZE)
 	lgCurMapSize = max(lgCurMapSize, _LG_MIN_MAP_SIZE)
 	hashMap, err := newReversePurgeLongHashMap(1 << lgCurMapSize)
@@ -82,8 +82,8 @@ func NewLongsSketch(lgMaxMapSize int, lgCurMapSize int) (*LongsSketch, error) {
 // NewLongsSketchWithMaxMapSize constructs a new LongsSketch with the given maxMapSize and the
 // default initialMapSize (8).
 //
-// maxMapSize determines the physical size of the internal hashFn map managed by this
-// sketch and must be a power of 2.  The maximum capacity of this internal hashFn map is
+// maxMapSize determines the physical size of the internal hash map managed by this
+// sketch and must be a power of 2.  The maximum capacity of this internal hash map is
 // 0.75 times * maxMapSize. Both the ultimate accuracy and size of this sketch are a
 // function of maxMapSize.
 func NewLongsSketchWithMaxMapSize(maxMapSize int) (*LongsSketch, error) {
@@ -284,7 +284,7 @@ func GetEpsilonLongsSketch(maxMapSize int) (float64, error) {
 }
 
 // GetEstimate gets the estimate of the frequency of the given item.
-// Note: The true frequency of a item would be the sum of the counts as a result of the
+// Note: The true frequency of an item would be the sum of the counts as a result of the
 // two update functions.
 //
 // item is the given item
@@ -324,7 +324,7 @@ func (s *LongsSketch) GetUpperBound(item int64) (int64, error) {
 	return itemCount + s.offset, nil
 }
 
-// GetFrequentItemsWithThreshold returns an array of Rows that include frequent items, estimates, upper and
+// GetFrequentItemsWithThreshold returns an array of Row that include frequent items, estimates, upper and
 // lower bounds given a threshold and an ErrorCondition. If the threshold is lower than
 // getMaximumError(), then getMaximumError() will be used instead.
 //
@@ -350,7 +350,7 @@ func (s *LongsSketch) GetFrequentItemsWithThreshold(threshold int64, errorType e
 	return s.sortItems(finalThreshold, errorType)
 }
 
-// GetFrequentItems returns an array of Rows that include frequent items, estimates, upper and
+// GetFrequentItems returns an array of Row that include frequent items, estimates, upper and
 // lower bounds given an ErrorCondition and the default threshold.
 // This is the same as GetFrequentItemsWithThreshold(getMaximumError(), errorType)
 //
@@ -396,19 +396,19 @@ func (s *LongsSketch) IsEmpty() bool {
 	return s.GetNumActiveItems() == 0
 }
 
-// Update update this sketch with an item and a frequency count of one.
+// Update this sketch with an item and a frequency count of one.
 //
 // item for which the frequency should be increased.
 func (s *LongsSketch) Update(item int64) error {
 	return s.UpdateMany(item, 1)
 }
 
-// UpdateMany update this sketch with a item and a positive frequency count (or weight).
+// UpdateMany this sketch with an item and a positive frequency count (or weight).
 //
-// item for which the frequency should be increased. The item can be any long value
+// Item for which the frequency should be increased. The item can be any long value
 // and is only used by the sketch to determine uniqueness.
 // count the amount by which the frequency of the item should be increased.
-// An count of zero is a no-op, and a negative count will throw an exception.
+// A count of zero is a no-op, and a negative count will throw an exception.
 func (s *LongsSketch) UpdateMany(item int64, count int64) error {
 	if count == 0 {
 		return nil

--- a/frequencies/longs_sketch.go
+++ b/frequencies/longs_sketch.go
@@ -29,7 +29,7 @@ import (
 	"github.com/apache/datasketches-go/internal"
 )
 
-type FrequencyLongsSketch struct {
+type LongsSketch struct {
 	// Log2 Maximum length of the arrays internal to the hashFn map supported by the data
 	// structure.
 	lgMaxMapSize int
@@ -50,19 +50,7 @@ const (
 	strPreambleTokens = 6
 )
 
-/**
- * Construct this sketch with parameter lgMapMapSize and lgCurMapSize. This internal
- * constructor is used when deserializing the sketch.
- *
- * @param lgMaxMapSize Log2 of the physical size of the internal hashFn map managed by this
- * sketch. The maximum capacity of this internal hashFn map is 0.75 times 2^lgMaxMapSize.
- * Both the ultimate accuracy and size of this sketch are a function of lgMaxMapSize.
- *
- * @param lgCurMapSize Log2 of the starting (current) physical size of the internal hashFn
- * map managed by this sketch.
- */
-
-// NewFrequencyLongsSketch returns a new FrequencyLongsSketch with the given lgMaxMapSize and lgCurMapSize.
+// NewLongsSketch returns a new LongsSketch with the given lgMaxMapSize and lgCurMapSize.
 //
 // lgMaxMapSize is the log2 of the physical size of the internal hashFn map managed by this
 // sketch. The maximum capacity of this internal hashFn map is 0.75 times 2^lgMaxMapSize.
@@ -70,7 +58,7 @@ const (
 //
 // lgCurMapSize is the log2 of the starting (current) physical size of the internal hashFn
 // map managed by this sketch.
-func NewFrequencyLongsSketch(lgMaxMapSize int, lgCurMapSize int) (*FrequencyLongsSketch, error) {
+func NewLongsSketch(lgMaxMapSize int, lgCurMapSize int) (*LongsSketch, error) {
 	//set initial size of hashFn map
 	lgMaxMapSize = max(lgMaxMapSize, _LG_MIN_MAP_SIZE)
 	lgCurMapSize = max(lgCurMapSize, _LG_MIN_MAP_SIZE)
@@ -82,7 +70,7 @@ func NewFrequencyLongsSketch(lgMaxMapSize int, lgCurMapSize int) (*FrequencyLong
 	maxMapCap := int(float64(uint64(1<<lgMaxMapSize)) * reversePurgeLongHashMapLoadFactor)
 	offset := int64(0)
 	sampleSize := min(_SAMPLE_SIZE, maxMapCap)
-	return &FrequencyLongsSketch{
+	return &LongsSketch{
 		lgMaxMapSize: lgMaxMapSize,
 		curMapCap:    curMapCap,
 		offset:       offset,
@@ -91,26 +79,26 @@ func NewFrequencyLongsSketch(lgMaxMapSize int, lgCurMapSize int) (*FrequencyLong
 	}, nil
 }
 
-// NewFrequencyLongsSketchWithMaxMapSize constructs a new FrequencyLongsSketch with the given maxMapSize and the
+// NewLongsSketchWithMaxMapSize constructs a new LongsSketch with the given maxMapSize and the
 // default initialMapSize (8).
 //
 // maxMapSize determines the physical size of the internal hashFn map managed by this
 // sketch and must be a power of 2.  The maximum capacity of this internal hashFn map is
 // 0.75 times * maxMapSize. Both the ultimate accuracy and size of this sketch are a
 // function of maxMapSize.
-func NewFrequencyLongsSketchWithMaxMapSize(maxMapSize int) (*FrequencyLongsSketch, error) {
+func NewLongsSketchWithMaxMapSize(maxMapSize int) (*LongsSketch, error) {
 	log2OfInt, err := internal.ExactLog2(maxMapSize)
 	if err != nil {
 		return nil, fmt.Errorf("maxMapSize, %e", err)
 	}
-	return NewFrequencyLongsSketch(log2OfInt, _LG_MIN_MAP_SIZE)
+	return NewLongsSketch(log2OfInt, _LG_MIN_MAP_SIZE)
 }
 
 // NewLongsSketchFromSlice returns a sketch instance of this class from the given slice,
 // which must be a byte slice representation of this sketch class.
 //
 // slc is a byte slice representation of a sketch of this class.
-func NewLongsSketchFromSlice(slc []byte) (*FrequencyLongsSketch, error) {
+func NewLongsSketchFromSlice(slc []byte) (*LongsSketch, error) {
 	pre0, err := checkPreambleSize(slc)
 	if err != nil {
 		return nil, err
@@ -140,14 +128,14 @@ func NewLongsSketchFromSlice(slc []byte) (*FrequencyLongsSketch, error) {
 		return nil, fmt.Errorf("possible Corruption: Empty Flag set incorrectly: %t", preLongsEq1)
 	}
 	if empty {
-		return NewFrequencyLongsSketch(lgMaxMapSize, _LG_MIN_MAP_SIZE)
+		return NewLongsSketch(lgMaxMapSize, _LG_MIN_MAP_SIZE)
 	}
 	// get full preamble
 	preArr := make([]int64, preLongs)
 	for i := 0; i < preLongs; i++ {
 		preArr[i] = int64(binary.LittleEndian.Uint64(slc[i<<3:]))
 	}
-	fls, err := NewFrequencyLongsSketch(lgMaxMapSize, lgCurMapSize)
+	fls, err := NewLongsSketch(lgMaxMapSize, lgCurMapSize)
 	if err != nil {
 		return nil, err
 	}
@@ -185,11 +173,11 @@ func NewLongsSketchFromSlice(slc []byte) (*FrequencyLongsSketch, error) {
 	return fls, nil
 }
 
-// NewFrequencyLongsSketchFromString returns a sketch instance of this class from the given string,
+// NewLongsSketchFromString returns a sketch instance of this class from the given string,
 // which must be a string representation of this sketch class.
 //
 // str is a string representation of a sketch of this class.
-func NewFrequencyLongsSketchFromString(str string) (*FrequencyLongsSketch, error) {
+func NewLongsSketchFromString(str string) (*LongsSketch, error) {
 	if len(str) < 1 {
 		return nil, errors.New("string is empty")
 	}
@@ -253,7 +241,7 @@ func NewFrequencyLongsSketchFromString(str string) (*FrequencyLongsSketch, error
 		return nil, fmt.Errorf("possible Corruption: Incorrect # of tokens: %d, numActive: %d", numTokens, numActive)
 	}
 	//    if ((2 * numActive) != (numTokens - STR_PREAMBLE_TOKENS - 2)) {
-	sk, err := NewFrequencyLongsSketch(int(lgMax), int(lgCur))
+	sk, err := NewLongsSketch(int(lgMax), int(lgCur))
 	if err != nil {
 		return nil, err
 	}
@@ -280,7 +268,7 @@ func GetAprioriErrorLongsSketch(maxMapSize int, estimatedTotalStreamWeight int64
 }
 
 // GetCurrentMapCapacity returns the current number of counters the sketch is configured to support.
-func (s *FrequencyLongsSketch) GetCurrentMapCapacity() int {
+func (s *LongsSketch) GetCurrentMapCapacity() int {
 	return s.curMapCap
 }
 
@@ -302,7 +290,7 @@ func GetEpsilonLongsSketch(maxMapSize int) (float64, error) {
 // item is the given item
 //
 // return the estimate of the frequency of the given item
-func (s *FrequencyLongsSketch) GetEstimate(item int64) (int64, error) {
+func (s *LongsSketch) GetEstimate(item int64) (int64, error) {
 	itemCount, err := s.hashMap.get(item)
 	if err != nil {
 		return 0, err
@@ -317,7 +305,7 @@ func (s *FrequencyLongsSketch) GetEstimate(item int64) (int64, error) {
 //
 // return the guaranteed lower bound frequency of the given item. That is, a number which
 // is guaranteed to be no larger than the real frequency.
-func (s *FrequencyLongsSketch) GetLowerBound(item int64) (int64, error) {
+func (s *LongsSketch) GetLowerBound(item int64) (int64, error) {
 	// LB = itemCount
 	return s.hashMap.get(item)
 }
@@ -328,7 +316,7 @@ func (s *FrequencyLongsSketch) GetLowerBound(item int64) (int64, error) {
 //
 // return the guaranteed upper bound frequency of the given item. That is, a number which
 // is guaranteed to be no smaller than the real frequency.
-func (s *FrequencyLongsSketch) GetUpperBound(item int64) (int64, error) {
+func (s *LongsSketch) GetUpperBound(item int64) (int64, error) {
 	itemCount, err := s.hashMap.get(item)
 	if err != nil {
 		return 0, err
@@ -354,7 +342,7 @@ func (s *FrequencyLongsSketch) GetUpperBound(item int64) (int64, error) {
 // threshold to include items in the result list
 // errorType determines whether no false positives or no false negatives are desired.
 // an array of frequent items
-func (s *FrequencyLongsSketch) GetFrequentItemsWithThreshold(threshold int64, errorType errorType) ([]*Row, error) {
+func (s *LongsSketch) GetFrequentItemsWithThreshold(threshold int64, errorType errorType) ([]*Row, error) {
 	finalThreshold := s.GetMaximumError()
 	if threshold > finalThreshold {
 		finalThreshold = threshold
@@ -367,30 +355,30 @@ func (s *FrequencyLongsSketch) GetFrequentItemsWithThreshold(threshold int64, er
 // This is the same as GetFrequentItemsWithThreshold(getMaximumError(), errorType)
 //
 // errorType determines whether no false positives or no false negatives are desired.
-func (s *FrequencyLongsSketch) GetFrequentItems(errorType errorType) ([]*Row, error) {
+func (s *LongsSketch) GetFrequentItems(errorType errorType) ([]*Row, error) {
 	return s.sortItems(s.GetMaximumError(), errorType)
 }
 
 // GetNumActiveItems returns the number of active items in the sketch.
-func (s *FrequencyLongsSketch) GetNumActiveItems() int {
+func (s *LongsSketch) GetNumActiveItems() int {
 	return s.hashMap.numActive
 }
 
 // GetMaximumError return an upper bound on the maximum error of GetEstimate(item) for any item.
 // This is equivalent to the maximum distance between the upper bound and the lower bound
 // for any item.
-func (s *FrequencyLongsSketch) GetMaximumError() int64 {
+func (s *LongsSketch) GetMaximumError() int64 {
 	return s.offset
 }
 
 // GetMaximumMapCapacity returns the maximum number of counters the sketch is configured to
 // support.
-func (s *FrequencyLongsSketch) GetMaximumMapCapacity() int {
+func (s *LongsSketch) GetMaximumMapCapacity() int {
 	return int(float64(uint64(1<<s.lgMaxMapSize)) * reversePurgeLongHashMapLoadFactor)
 }
 
 // GetStorageBytes returns the number of bytes required to store this sketch as slice
-func (s *FrequencyLongsSketch) GetStorageBytes() int {
+func (s *LongsSketch) GetStorageBytes() int {
 	if s.IsEmpty() {
 		return 8
 	}
@@ -399,19 +387,19 @@ func (s *FrequencyLongsSketch) GetStorageBytes() int {
 
 // GetStreamLength returns the sum of the frequencies (weights or counts) in the stream seen
 // so far by the sketch
-func (s *FrequencyLongsSketch) GetStreamLength() int64 {
+func (s *LongsSketch) GetStreamLength() int64 {
 	return s.streamWeight
 }
 
 // IsEmpty returns true if this sketch is empty
-func (s *FrequencyLongsSketch) IsEmpty() bool {
+func (s *LongsSketch) IsEmpty() bool {
 	return s.GetNumActiveItems() == 0
 }
 
 // Update update this sketch with an item and a frequency count of one.
 //
 // item for which the frequency should be increased.
-func (s *FrequencyLongsSketch) Update(item int64) error {
+func (s *LongsSketch) Update(item int64) error {
 	return s.UpdateMany(item, 1)
 }
 
@@ -421,7 +409,7 @@ func (s *FrequencyLongsSketch) Update(item int64) error {
 // and is only used by the sketch to determine uniqueness.
 // count the amount by which the frequency of the item should be increased.
 // An count of zero is a no-op, and a negative count will throw an exception.
-func (s *FrequencyLongsSketch) UpdateMany(item int64, count int64) error {
+func (s *LongsSketch) UpdateMany(item int64, count int64) error {
 	if count == 0 {
 		return nil
 	}
@@ -460,7 +448,7 @@ func (s *FrequencyLongsSketch) UpdateMany(item int64, count int64) error {
 //
 // return a sketch whose estimates are within the guarantees of the largest error tolerance
 // of the two merged sketches.
-func (s *FrequencyLongsSketch) Merge(other *FrequencyLongsSketch) (*FrequencyLongsSketch, error) {
+func (s *LongsSketch) Merge(other *LongsSketch) (*LongsSketch, error) {
 	if other == nil || other.IsEmpty() {
 		return s, nil
 	}
@@ -478,7 +466,7 @@ func (s *FrequencyLongsSketch) Merge(other *FrequencyLongsSketch) (*FrequencyLon
 }
 
 // ToString returns a String representation of this sketch
-func (s *FrequencyLongsSketch) ToString() (string, error) {
+func (s *LongsSketch) ToString() (string, error) {
 	var sb strings.Builder
 	//start the string with parameters of the sketch
 	serVer := _SER_VER //0
@@ -497,7 +485,7 @@ func (s *FrequencyLongsSketch) ToString() (string, error) {
 }
 
 // ToSlice returns a slice representation of this sketch
-func (s *FrequencyLongsSketch) ToSlice() []byte {
+func (s *LongsSketch) ToSlice() []byte {
 	emtpy := s.IsEmpty()
 	activeItems := s.GetNumActiveItems()
 	preLongs := 1
@@ -547,7 +535,7 @@ func (s *FrequencyLongsSketch) ToSlice() []byte {
 }
 
 // Reset resets this sketch to a virgin state.
-func (s *FrequencyLongsSketch) Reset() {
+func (s *LongsSketch) Reset() {
 	hasMap, _ := newReversePurgeLongHashMap(1 << _LG_MIN_MAP_SIZE)
 	s.curMapCap = hasMap.getCapacity()
 	s.offset = 0
@@ -555,7 +543,7 @@ func (s *FrequencyLongsSketch) Reset() {
 	s.hashMap = hasMap
 }
 
-func (s *FrequencyLongsSketch) String() string {
+func (s *LongsSketch) String() string {
 	var sb strings.Builder
 	sb.WriteString("FrequentLongsSketch:")
 	sb.WriteString("\n")
@@ -567,7 +555,7 @@ func (s *FrequencyLongsSketch) String() string {
 	return sb.String()
 }
 
-func (s *FrequencyLongsSketch) sortItems(threshold int64, errorType errorType) ([]*Row, error) {
+func (s *LongsSketch) sortItems(threshold int64, errorType errorType) ([]*Row, error) {
 	rowList := make([]*Row, 0)
 	iter := s.hashMap.iterator()
 	if errorType == ErrorTypeEnum.NoFalseNegatives {

--- a/frequencies/longs_sketch.go
+++ b/frequencies/longs_sketch.go
@@ -29,10 +29,10 @@ import (
 )
 
 type LongsSketch struct {
-	// Log2 Maximum length of the arrays internal to the hash map supported by the data
+	// Log2 Maximum length of the arrays internal to the hashFn map supported by the data
 	// structure.
 	lgMaxMapSize int
-	// The current number of counters supported by the hash map.
+	// The current number of counters supported by the hashFn map.
 	curMapCap int //the threshold to purge
 	// Tracks the total of decremented counts.
 	offset int64
@@ -53,24 +53,24 @@ const (
  * Construct this sketch with parameter lgMapMapSize and lgCurMapSize. This internal
  * constructor is used when deserializing the sketch.
  *
- * @param lgMaxMapSize Log2 of the physical size of the internal hash map managed by this
- * sketch. The maximum capacity of this internal hash map is 0.75 times 2^lgMaxMapSize.
+ * @param lgMaxMapSize Log2 of the physical size of the internal hashFn map managed by this
+ * sketch. The maximum capacity of this internal hashFn map is 0.75 times 2^lgMaxMapSize.
  * Both the ultimate accuracy and size of this sketch are a function of lgMaxMapSize.
  *
- * @param lgCurMapSize Log2 of the starting (current) physical size of the internal hash
+ * @param lgCurMapSize Log2 of the starting (current) physical size of the internal hashFn
  * map managed by this sketch.
  */
 
 // NewLongsSketch returns a new LongsSketch with the given lgMaxMapSize and lgCurMapSize.
 //
-// lgMaxMapSize is the log2 of the physical size of the internal hash map managed by this
-// sketch. The maximum capacity of this internal hash map is 0.75 times 2^lgMaxMapSize.
+// lgMaxMapSize is the log2 of the physical size of the internal hashFn map managed by this
+// sketch. The maximum capacity of this internal hashFn map is 0.75 times 2^lgMaxMapSize.
 // Both the ultimate accuracy and size of this sketch are a function of lgMaxMapSize.
 //
-// lgCurMapSize is the log2 of the starting (current) physical size of the internal hash
+// lgCurMapSize is the log2 of the starting (current) physical size of the internal hashFn
 // map managed by this sketch.
 func NewLongsSketch(lgMaxMapSize int, lgCurMapSize int) (*LongsSketch, error) {
-	//set initial size of hash map
+	//set initial size of hashFn map
 	lgMaxMapSize = max(lgMaxMapSize, _LG_MIN_MAP_SIZE)
 	lgCurMapSize = max(lgCurMapSize, _LG_MIN_MAP_SIZE)
 	hashMap, err := newReversePurgeLongHashMap(1 << lgCurMapSize)
@@ -93,8 +93,8 @@ func NewLongsSketch(lgMaxMapSize int, lgCurMapSize int) (*LongsSketch, error) {
 // NewLongsSketchWithMaxMapSize constructs a new LongsSketch with the given maxMapSize and the
 // default initialMapSize (8).
 //
-// maxMapSize determines the physical size of the internal hash map managed by this
-// sketch and must be a power of 2.  The maximum capacity of this internal hash map is
+// maxMapSize determines the physical size of the internal hashFn map managed by this
+// sketch and must be a power of 2.  The maximum capacity of this internal hashFn map is
 // 0.75 times * maxMapSize. Both the ultimate accuracy and size of this sketch are a
 // function of maxMapSize.
 func NewLongsSketchWithMaxMapSize(maxMapSize int) (*LongsSketch, error) {

--- a/frequencies/longs_sketch_serialization_test.go
+++ b/frequencies/longs_sketch_serialization_test.go
@@ -52,8 +52,7 @@ func TestGenerateGoBinariesForCompatibilityTestingLongsSketch(t *testing.T) {
 		err = os.MkdirAll(internal.GoPath, os.ModePerm)
 		assert.NoError(t, err)
 
-		slc, err := sk.ToSlice()
-		assert.NoError(t, err)
+		slc := sk.ToSlice()
 		err = os.WriteFile(fmt.Sprintf("%s/frequent_long_n%d_go.sk", internal.GoPath, n), slc, 0644)
 		if err != nil {
 			t.Errorf("err != nil")

--- a/frequencies/longs_sketch_serialization_test.go
+++ b/frequencies/longs_sketch_serialization_test.go
@@ -33,7 +33,7 @@ func TestGenerateGoBinariesForCompatibilityTestingLongsSketch(t *testing.T) {
 
 	nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 	for _, n := range nArr {
-		sk, err := NewLongsSketchWithMaxMapSize(64)
+		sk, err := NewFrequencyLongsSketchWithMaxMapSize(64)
 		assert.NoError(t, err)
 		for i := 1; i <= n; i++ {
 			err = sk.Update(int64(i))

--- a/frequencies/longs_sketch_serialization_test.go
+++ b/frequencies/longs_sketch_serialization_test.go
@@ -33,7 +33,7 @@ func TestGenerateGoBinariesForCompatibilityTestingLongsSketch(t *testing.T) {
 
 	nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 	for _, n := range nArr {
-		sk, err := NewFrequencyLongsSketchWithMaxMapSize(64)
+		sk, err := NewLongsSketchWithMaxMapSize(64)
 		assert.NoError(t, err)
 		for i := 1; i <= n; i++ {
 			err = sk.Update(int64(i))

--- a/frequencies/longs_sketch_test.go
+++ b/frequencies/longs_sketch_test.go
@@ -96,7 +96,7 @@ func TestFrequentItemsStringSerial(t *testing.T) {
 func TestFrequentItemsByteSerial(t *testing.T) {
 	sketch, err := NewLongsSketchWithMaxMapSize(16)
 	assert.NoError(t, err)
-	byteArray0, err := sketch.ToSlice()
+	byteArray0 := sketch.ToSlice()
 	newSk0, err := NewLongsSketchFromSlice(byteArray0)
 	assert.NoError(t, err)
 	str0, err := sketch.ToString()
@@ -113,8 +113,7 @@ func TestFrequentItemsByteSerial(t *testing.T) {
 	sketch.UpdateMany(1000001, 1010230)
 	sketch.UpdateMany(1000002, 1010230)
 
-	byteArray1, err := sketch.ToSlice()
-	assert.NoError(t, err)
+	byteArray1 := sketch.ToSlice()
 	newSk1, err := NewLongsSketchFromSlice(byteArray1)
 	assert.NoError(t, err)
 	str1, err := sketch.ToString()
@@ -144,8 +143,7 @@ func TestFrequentItemsByteSerial(t *testing.T) {
 	sketch2.UpdateMany(207, 12902390)
 	sketch2.UpdateMany(208, 12902390)
 
-	byteArray2, err := sketch2.ToSlice()
-	assert.NoError(t, err)
+	byteArray2 := sketch2.ToSlice()
 	newSk2, err := NewLongsSketchFromSlice(byteArray2)
 	assert.NoError(t, err)
 	str2, err := sketch2.ToString()
@@ -159,8 +157,7 @@ func TestFrequentItemsByteSerial(t *testing.T) {
 
 	mergedSketch, err := sketch.Merge(sketch2)
 	assert.NoError(t, err)
-	byteArray3, err := mergedSketch.ToSlice()
-	assert.NoError(t, err)
+	byteArray3 := mergedSketch.ToSlice()
 	newSk3, err := NewLongsSketchFromSlice(byteArray3)
 	assert.NoError(t, err)
 	str3, err := mergedSketch.ToString()
@@ -183,8 +180,7 @@ func TestFrequentItemsByteResetAndEmptySerial(t *testing.T) {
 	sketch.UpdateMany(1000002, 1010230)
 	sketch.Reset()
 
-	byteArray0, err := sketch.ToSlice()
-	assert.NoError(t, err)
+	byteArray0 := sketch.ToSlice()
 	newSk0, err := NewLongsSketchFromSlice(byteArray0)
 	assert.NoError(t, err)
 	str0, err := sketch.ToString()
@@ -206,8 +202,7 @@ func TestFreqLongSliceSerDe(t *testing.T) {
 	sk1.UpdateMany(1000001, 1010230)
 	sk1.UpdateMany(1000002, 1010230)
 
-	byteArray0, err := sk1.ToSlice()
-	assert.NoError(t, err)
+	byteArray0 := sk1.ToSlice()
 	sk2, err := NewLongsSketchFromSlice(byteArray0)
 	assert.NoError(t, err)
 
@@ -273,7 +268,7 @@ func TestFreqLongSliceSerDeError(t *testing.T) {
 	assert.NoError(t, err)
 	sk1.Update(1)
 
-	byteArray0, err := sk1.ToSlice()
+	byteArray0 := sk1.ToSlice()
 	pre0 := binary.LittleEndian.Uint64(byteArray0)
 
 	tryBadMem(t, byteArray0, _PREAMBLE_LONGS_BYTE, 2) //Corrupt
@@ -420,13 +415,11 @@ func TestGetStorageByes(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
 	fls, err := NewLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
-	sl, err := fls.ToSlice()
-	assert.NoError(t, err)
+	sl := fls.ToSlice()
 	assert.Equal(t, len(sl), fls.GetStorageBytes())
 	err = fls.Update(1)
 	assert.NoError(t, err)
-	sl, err = fls.ToSlice()
-	assert.NoError(t, err)
+	sl = fls.ToSlice()
 	assert.Equal(t, len(sl), fls.GetStorageBytes())
 }
 

--- a/frequencies/longs_sketch_test.go
+++ b/frequencies/longs_sketch_test.go
@@ -28,9 +28,9 @@ import (
 )
 
 func TestFrequentItemsStringSerial(t *testing.T) {
-	sketch, err := NewLongsSketchWithMaxMapSize(8)
+	sketch, err := NewFrequencyLongsSketchWithMaxMapSize(8)
 	assert.NoError(t, err)
-	sketch2, err := NewLongsSketchWithMaxMapSize(128)
+	sketch2, err := NewFrequencyLongsSketchWithMaxMapSize(128)
 	assert.NoError(t, err)
 	sketch.UpdateMany(10, 100)
 	sketch.UpdateMany(10, 100)
@@ -40,7 +40,7 @@ func TestFrequentItemsStringSerial(t *testing.T) {
 
 	ser, err := sketch.ToString()
 	assert.NoError(t, err)
-	newSk0, err := NewLongsSketchFromString(ser)
+	newSk0, err := NewFrequencyLongsSketchFromString(ser)
 	assert.NoError(t, err)
 	newSer0, err := newSk0.ToString()
 	assert.NoError(t, err)
@@ -70,7 +70,7 @@ func TestFrequentItemsStringSerial(t *testing.T) {
 
 	s2, err := sketch2.ToString()
 	assert.NoError(t, err)
-	newSk2, err := NewLongsSketchFromString(s2)
+	newSk2, err := NewFrequencyLongsSketchFromString(s2)
 	assert.NoError(t, err)
 	newS2, err := newSk2.ToString()
 	assert.NoError(t, err)
@@ -83,7 +83,7 @@ func TestFrequentItemsStringSerial(t *testing.T) {
 	assert.NoError(t, err)
 	ms, err := mergedSketch.ToString()
 	assert.NoError(t, err)
-	newMs, err := NewLongsSketchFromString(ms)
+	newMs, err := NewFrequencyLongsSketchFromString(ms)
 	assert.NoError(t, err)
 	newSMs, err := newMs.ToString()
 	assert.NoError(t, err)
@@ -94,7 +94,7 @@ func TestFrequentItemsStringSerial(t *testing.T) {
 }
 
 func TestFrequentItemsByteSerial(t *testing.T) {
-	sketch, err := NewLongsSketchWithMaxMapSize(16)
+	sketch, err := NewFrequencyLongsSketchWithMaxMapSize(16)
 	assert.NoError(t, err)
 	byteArray0 := sketch.ToSlice()
 	newSk0, err := NewLongsSketchFromSlice(byteArray0)
@@ -105,7 +105,7 @@ func TestFrequentItemsByteSerial(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, str0, newStr0)
 
-	sketch2, err := NewLongsSketchWithMaxMapSize(128)
+	sketch2, err := NewFrequencyLongsSketchWithMaxMapSize(128)
 	assert.NoError(t, err)
 	sketch.UpdateMany(10, 100)
 	sketch.UpdateMany(10, 100)
@@ -171,7 +171,7 @@ func TestFrequentItemsByteSerial(t *testing.T) {
 }
 
 func TestFrequentItemsByteResetAndEmptySerial(t *testing.T) {
-	sketch, err := NewLongsSketchWithMaxMapSize(16)
+	sketch, err := NewFrequencyLongsSketchWithMaxMapSize(16)
 	assert.NoError(t, err)
 	sketch.UpdateMany(10, 100)
 	sketch.UpdateMany(10, 100)
@@ -194,7 +194,7 @@ func TestFrequentItemsByteResetAndEmptySerial(t *testing.T) {
 
 func TestFreqLongSliceSerDe(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
-	sk1, err := NewLongsSketchWithMaxMapSize(minSize)
+	sk1, err := NewFrequencyLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
 	sk1.UpdateMany(10, 100)
 	sk1.UpdateMany(10, 100)
@@ -211,7 +211,7 @@ func TestFreqLongSliceSerDe(t *testing.T) {
 
 func TestFreqLongStringSerDe(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
-	sk1, err := NewLongsSketchWithMaxMapSize(minSize)
+	sk1, err := NewFrequencyLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
 	sk1.UpdateMany(10, 100)
 	sk1.UpdateMany(10, 100)
@@ -221,13 +221,13 @@ func TestFreqLongStringSerDe(t *testing.T) {
 
 	str1, err := sk1.ToString()
 	assert.NoError(t, err)
-	sk2, err := NewLongsSketchFromString(str1)
+	sk2, err := NewFrequencyLongsSketchFromString(str1)
 	assert.NoError(t, err)
 
 	checkEquality(t, sk1, sk2)
 }
 
-func checkEquality(t *testing.T, sk1, sk2 *LongsSketch) {
+func checkEquality(t *testing.T, sk1, sk2 *FrequencyLongsSketch) {
 	assert.Equal(t, sk1.GetNumActiveItems(), sk2.GetNumActiveItems())
 	assert.Equal(t, sk1.GetCurrentMapCapacity(), sk2.GetCurrentMapCapacity())
 	assert.Equal(t, sk1.GetMaximumError(), sk2.GetMaximumError())
@@ -264,7 +264,7 @@ func checkEquality(t *testing.T, sk1, sk2 *LongsSketch) {
 
 func TestFreqLongSliceSerDeError(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
-	sk1, err := NewLongsSketchWithMaxMapSize(minSize)
+	sk1, err := NewFrequencyLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
 	sk1.Update(1)
 
@@ -292,7 +292,7 @@ func tryBadMem(t *testing.T, mem []byte, byteOffset, byteValue int) {
 }
 
 func TestFreqLongStringSerDeError(t *testing.T) {
-	// sk1, err := NewLongsSketchWithMaxMapSize(8)
+	// sk1, err := NewFrequencyLongsSketchWithMaxMapSize(8)
 	// str1 := sk1.ToString()
 	// correct   = "1,10,2,4,0,0,0,4,";
 
@@ -302,7 +302,7 @@ func TestFreqLongStringSerDeError(t *testing.T) {
 }
 
 func tryBadString(t *testing.T, badString string) {
-	_, err := NewLongsSketchFromString(badString)
+	_, err := NewFrequencyLongsSketchFromString(badString)
 	assert.Error(t, err)
 }
 
@@ -311,7 +311,7 @@ func TestFreqLongs(t *testing.T) {
 	n := 2222
 	errorTolerance := 1.0 / 100
 
-	sketches := make([]*LongsSketch, numSketches)
+	sketches := make([]*FrequencyLongsSketch, numSketches)
 	for h := 0; h < numSketches; h++ {
 		sketches[h], _ = newFrequencySketch(errorTolerance)
 	}
@@ -343,9 +343,9 @@ func TestFreqLongs(t *testing.T) {
 	}
 }
 
-func newFrequencySketch(eps float64) (*LongsSketch, error) {
+func newFrequencySketch(eps float64) (*FrequencyLongsSketch, error) {
 	maxMapSize := internal.CeilPowerOf2(int(1.0 / (eps * reversePurgeLongHashMapLoadFactor)))
-	return NewLongsSketchWithMaxMapSize(maxMapSize)
+	return NewFrequencyLongsSketchWithMaxMapSize(maxMapSize)
 }
 
 func TestUpdateOneTime(t *testing.T) {
@@ -377,13 +377,13 @@ func TestGetInstanceSlice(t *testing.T) {
 }
 
 func TestGetInstanceString(t *testing.T) {
-	_, err := NewLongsSketchFromString("")
+	_, err := NewFrequencyLongsSketchFromString("")
 	assert.Error(t, err)
 }
 
 func TestUpdateNegative(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
-	fls, err := NewLongsSketchWithMaxMapSize(minSize)
+	fls, err := NewFrequencyLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
 	err = fls.UpdateMany(1, 0)
 	assert.NoError(t, err)
@@ -393,7 +393,7 @@ func TestUpdateNegative(t *testing.T) {
 
 func TestGetFrequentItems1(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
-	fls, err := NewLongsSketchWithMaxMapSize(minSize)
+	fls, err := NewFrequencyLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
 	fls.Update(1)
 	rowArr, err := fls.GetFrequentItems(ErrorTypeEnum.NoFalsePositives)
@@ -413,7 +413,7 @@ func TestGetFrequentItems1(t *testing.T) {
 
 func TestGetStorageByes(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
-	fls, err := NewLongsSketchWithMaxMapSize(minSize)
+	fls, err := NewFrequencyLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
 	sl := fls.ToSlice()
 	assert.Equal(t, len(sl), fls.GetStorageBytes())
@@ -425,7 +425,7 @@ func TestGetStorageByes(t *testing.T) {
 
 func TestDeSerFromString(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
-	fls, err := NewLongsSketchWithMaxMapSize(minSize)
+	fls, err := NewFrequencyLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
 	str, err := fls.ToString()
 	fmt.Println(str)
@@ -438,15 +438,15 @@ func TestDeSerFromString(t *testing.T) {
 
 func TestMerge(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
-	fls1, err := NewLongsSketchWithMaxMapSize(minSize)
+	fls1, err := NewFrequencyLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
-	var fls2 *LongsSketch
+	var fls2 *FrequencyLongsSketch
 	fls2 = nil
 	fle, err := fls1.Merge(fls2)
 	assert.NoError(t, err)
 	assert.True(t, fle.IsEmpty())
 
-	fls2, err = NewLongsSketchWithMaxMapSize(minSize)
+	fls2, err = NewFrequencyLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
 	fle, err = fls1.Merge(fls2)
 	assert.NoError(t, err)
@@ -459,7 +459,7 @@ func TestSortItems(t *testing.T) {
 	sketchSize := internal.CeilPowerOf2(int(1.0 / (errorTolerance * reversePurgeLongHashMapLoadFactor)))
 	fmt.Printf("sketchSize: %d\n", sketchSize)
 
-	sketches := make([]*LongsSketch, numSketches)
+	sketches := make([]*FrequencyLongsSketch, numSketches)
 	for h := 0; h < numSketches; h++ {
 		sketches[h], _ = newFrequencySketch(float64(sketchSize))
 	}
@@ -508,7 +508,7 @@ func TestToString1(t *testing.T) {
 
 func printSketch(t *testing.T, size int, items []int64) {
 	var sb strings.Builder
-	fls, err := NewLongsSketchWithMaxMapSize(size)
+	fls, err := NewFrequencyLongsSketchWithMaxMapSize(size)
 	assert.NoError(t, err)
 	for i := 0; i < len(items); i++ {
 		fls.UpdateMany(int64(i+1), items[i])
@@ -522,7 +522,7 @@ func printSketch(t *testing.T, size int, items []int64) {
 	fmt.Println("")
 }
 
-func printRows(t *testing.T, fls *LongsSketch, errorType errorType) {
+func printRows(t *testing.T, fls *FrequencyLongsSketch, errorType errorType) {
 	rows, err := fls.GetFrequentItems(errorType)
 	assert.NoError(t, err)
 	fmt.Println(errorType.Name)
@@ -543,7 +543,7 @@ func TestStringDeserEmptyNotCorrupt(t *testing.T) {
 	size := 1 << _LG_MIN_MAP_SIZE
 	thresh := (size * 3) / 4
 	format := "%6d%10s%s"
-	fls, err := NewLongsSketchWithMaxMapSize(size)
+	fls, err := NewFrequencyLongsSketchWithMaxMapSize(size)
 	assert.NoError(t, err)
 	fmt.Printf("Sketch Size: %d\n", size)
 	for i := 0; i <= thresh; i++ {
@@ -552,7 +552,7 @@ func TestStringDeserEmptyNotCorrupt(t *testing.T) {
 		s, err := fls.ToString()
 		assert.NoError(t, err)
 		fmt.Printf("SER   "+format+"\n", (i + 1), fmt.Sprintf("%t : ", fls.IsEmpty()), s)
-		fls2, err := NewLongsSketchFromString(s)
+		fls2, err := NewFrequencyLongsSketchFromString(s)
 		assert.NoError(t, err)
 		fmt.Printf("DESER "+format+"\n", (i + 1), fmt.Sprintf("%t : ", fls2.IsEmpty()), s)
 	}
@@ -568,7 +568,7 @@ func TestStringDeserEmptyCorrupt(t *testing.T) {
 	s.WriteString("1,")  //error offset
 	s.WriteString("0,")  //numActive ...conflict with empty
 	s.WriteString("8,")  //curMapLen
-	_, err := NewLongsSketchFromString(s.String())
+	_, err := NewFrequencyLongsSketchFromString(s.String())
 	assert.Error(t, err)
 }
 
@@ -589,7 +589,7 @@ func TestGetAprioriError(t *testing.T) {
 }
 
 func BenchmarkLongSketch(b *testing.B) {
-	sketch, err := NewLongsSketch(128, 8)
+	sketch, err := NewFrequencyLongsSketch(128, 8)
 	assert.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		sketch.Update(int64(i))

--- a/frequencies/longs_sketch_test.go
+++ b/frequencies/longs_sketch_test.go
@@ -28,9 +28,9 @@ import (
 )
 
 func TestFrequentItemsStringSerial(t *testing.T) {
-	sketch, err := NewFrequencyLongsSketchWithMaxMapSize(8)
+	sketch, err := NewLongsSketchWithMaxMapSize(8)
 	assert.NoError(t, err)
-	sketch2, err := NewFrequencyLongsSketchWithMaxMapSize(128)
+	sketch2, err := NewLongsSketchWithMaxMapSize(128)
 	assert.NoError(t, err)
 	sketch.UpdateMany(10, 100)
 	sketch.UpdateMany(10, 100)
@@ -40,7 +40,7 @@ func TestFrequentItemsStringSerial(t *testing.T) {
 
 	ser, err := sketch.ToString()
 	assert.NoError(t, err)
-	newSk0, err := NewFrequencyLongsSketchFromString(ser)
+	newSk0, err := NewLongsSketchFromString(ser)
 	assert.NoError(t, err)
 	newSer0, err := newSk0.ToString()
 	assert.NoError(t, err)
@@ -70,7 +70,7 @@ func TestFrequentItemsStringSerial(t *testing.T) {
 
 	s2, err := sketch2.ToString()
 	assert.NoError(t, err)
-	newSk2, err := NewFrequencyLongsSketchFromString(s2)
+	newSk2, err := NewLongsSketchFromString(s2)
 	assert.NoError(t, err)
 	newS2, err := newSk2.ToString()
 	assert.NoError(t, err)
@@ -83,7 +83,7 @@ func TestFrequentItemsStringSerial(t *testing.T) {
 	assert.NoError(t, err)
 	ms, err := mergedSketch.ToString()
 	assert.NoError(t, err)
-	newMs, err := NewFrequencyLongsSketchFromString(ms)
+	newMs, err := NewLongsSketchFromString(ms)
 	assert.NoError(t, err)
 	newSMs, err := newMs.ToString()
 	assert.NoError(t, err)
@@ -94,7 +94,7 @@ func TestFrequentItemsStringSerial(t *testing.T) {
 }
 
 func TestFrequentItemsByteSerial(t *testing.T) {
-	sketch, err := NewFrequencyLongsSketchWithMaxMapSize(16)
+	sketch, err := NewLongsSketchWithMaxMapSize(16)
 	assert.NoError(t, err)
 	byteArray0 := sketch.ToSlice()
 	newSk0, err := NewLongsSketchFromSlice(byteArray0)
@@ -105,7 +105,7 @@ func TestFrequentItemsByteSerial(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, str0, newStr0)
 
-	sketch2, err := NewFrequencyLongsSketchWithMaxMapSize(128)
+	sketch2, err := NewLongsSketchWithMaxMapSize(128)
 	assert.NoError(t, err)
 	sketch.UpdateMany(10, 100)
 	sketch.UpdateMany(10, 100)
@@ -171,7 +171,7 @@ func TestFrequentItemsByteSerial(t *testing.T) {
 }
 
 func TestFrequentItemsByteResetAndEmptySerial(t *testing.T) {
-	sketch, err := NewFrequencyLongsSketchWithMaxMapSize(16)
+	sketch, err := NewLongsSketchWithMaxMapSize(16)
 	assert.NoError(t, err)
 	sketch.UpdateMany(10, 100)
 	sketch.UpdateMany(10, 100)
@@ -194,7 +194,7 @@ func TestFrequentItemsByteResetAndEmptySerial(t *testing.T) {
 
 func TestFreqLongSliceSerDe(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
-	sk1, err := NewFrequencyLongsSketchWithMaxMapSize(minSize)
+	sk1, err := NewLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
 	sk1.UpdateMany(10, 100)
 	sk1.UpdateMany(10, 100)
@@ -211,7 +211,7 @@ func TestFreqLongSliceSerDe(t *testing.T) {
 
 func TestFreqLongStringSerDe(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
-	sk1, err := NewFrequencyLongsSketchWithMaxMapSize(minSize)
+	sk1, err := NewLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
 	sk1.UpdateMany(10, 100)
 	sk1.UpdateMany(10, 100)
@@ -221,13 +221,13 @@ func TestFreqLongStringSerDe(t *testing.T) {
 
 	str1, err := sk1.ToString()
 	assert.NoError(t, err)
-	sk2, err := NewFrequencyLongsSketchFromString(str1)
+	sk2, err := NewLongsSketchFromString(str1)
 	assert.NoError(t, err)
 
 	checkEquality(t, sk1, sk2)
 }
 
-func checkEquality(t *testing.T, sk1, sk2 *FrequencyLongsSketch) {
+func checkEquality(t *testing.T, sk1, sk2 *LongsSketch) {
 	assert.Equal(t, sk1.GetNumActiveItems(), sk2.GetNumActiveItems())
 	assert.Equal(t, sk1.GetCurrentMapCapacity(), sk2.GetCurrentMapCapacity())
 	assert.Equal(t, sk1.GetMaximumError(), sk2.GetMaximumError())
@@ -264,7 +264,7 @@ func checkEquality(t *testing.T, sk1, sk2 *FrequencyLongsSketch) {
 
 func TestFreqLongSliceSerDeError(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
-	sk1, err := NewFrequencyLongsSketchWithMaxMapSize(minSize)
+	sk1, err := NewLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
 	sk1.Update(1)
 
@@ -292,7 +292,7 @@ func tryBadMem(t *testing.T, mem []byte, byteOffset, byteValue int) {
 }
 
 func TestFreqLongStringSerDeError(t *testing.T) {
-	// sk1, err := NewFrequencyLongsSketchWithMaxMapSize(8)
+	// sk1, err := NewLongsSketchWithMaxMapSize(8)
 	// str1 := sk1.ToString()
 	// correct   = "1,10,2,4,0,0,0,4,";
 
@@ -302,7 +302,7 @@ func TestFreqLongStringSerDeError(t *testing.T) {
 }
 
 func tryBadString(t *testing.T, badString string) {
-	_, err := NewFrequencyLongsSketchFromString(badString)
+	_, err := NewLongsSketchFromString(badString)
 	assert.Error(t, err)
 }
 
@@ -311,7 +311,7 @@ func TestFreqLongs(t *testing.T) {
 	n := 2222
 	errorTolerance := 1.0 / 100
 
-	sketches := make([]*FrequencyLongsSketch, numSketches)
+	sketches := make([]*LongsSketch, numSketches)
 	for h := 0; h < numSketches; h++ {
 		sketches[h], _ = newFrequencySketch(errorTolerance)
 	}
@@ -343,9 +343,9 @@ func TestFreqLongs(t *testing.T) {
 	}
 }
 
-func newFrequencySketch(eps float64) (*FrequencyLongsSketch, error) {
+func newFrequencySketch(eps float64) (*LongsSketch, error) {
 	maxMapSize := internal.CeilPowerOf2(int(1.0 / (eps * reversePurgeLongHashMapLoadFactor)))
-	return NewFrequencyLongsSketchWithMaxMapSize(maxMapSize)
+	return NewLongsSketchWithMaxMapSize(maxMapSize)
 }
 
 func TestUpdateOneTime(t *testing.T) {
@@ -377,13 +377,13 @@ func TestGetInstanceSlice(t *testing.T) {
 }
 
 func TestGetInstanceString(t *testing.T) {
-	_, err := NewFrequencyLongsSketchFromString("")
+	_, err := NewLongsSketchFromString("")
 	assert.Error(t, err)
 }
 
 func TestUpdateNegative(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
-	fls, err := NewFrequencyLongsSketchWithMaxMapSize(minSize)
+	fls, err := NewLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
 	err = fls.UpdateMany(1, 0)
 	assert.NoError(t, err)
@@ -393,7 +393,7 @@ func TestUpdateNegative(t *testing.T) {
 
 func TestGetFrequentItems1(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
-	fls, err := NewFrequencyLongsSketchWithMaxMapSize(minSize)
+	fls, err := NewLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
 	fls.Update(1)
 	rowArr, err := fls.GetFrequentItems(ErrorTypeEnum.NoFalsePositives)
@@ -413,7 +413,7 @@ func TestGetFrequentItems1(t *testing.T) {
 
 func TestGetStorageByes(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
-	fls, err := NewFrequencyLongsSketchWithMaxMapSize(minSize)
+	fls, err := NewLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
 	sl := fls.ToSlice()
 	assert.Equal(t, len(sl), fls.GetStorageBytes())
@@ -425,7 +425,7 @@ func TestGetStorageByes(t *testing.T) {
 
 func TestDeSerFromString(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
-	fls, err := NewFrequencyLongsSketchWithMaxMapSize(minSize)
+	fls, err := NewLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
 	str, err := fls.ToString()
 	fmt.Println(str)
@@ -438,15 +438,15 @@ func TestDeSerFromString(t *testing.T) {
 
 func TestMerge(t *testing.T) {
 	minSize := 1 << _LG_MIN_MAP_SIZE
-	fls1, err := NewFrequencyLongsSketchWithMaxMapSize(minSize)
+	fls1, err := NewLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
-	var fls2 *FrequencyLongsSketch
+	var fls2 *LongsSketch
 	fls2 = nil
 	fle, err := fls1.Merge(fls2)
 	assert.NoError(t, err)
 	assert.True(t, fle.IsEmpty())
 
-	fls2, err = NewFrequencyLongsSketchWithMaxMapSize(minSize)
+	fls2, err = NewLongsSketchWithMaxMapSize(minSize)
 	assert.NoError(t, err)
 	fle, err = fls1.Merge(fls2)
 	assert.NoError(t, err)
@@ -459,7 +459,7 @@ func TestSortItems(t *testing.T) {
 	sketchSize := internal.CeilPowerOf2(int(1.0 / (errorTolerance * reversePurgeLongHashMapLoadFactor)))
 	fmt.Printf("sketchSize: %d\n", sketchSize)
 
-	sketches := make([]*FrequencyLongsSketch, numSketches)
+	sketches := make([]*LongsSketch, numSketches)
 	for h := 0; h < numSketches; h++ {
 		sketches[h], _ = newFrequencySketch(float64(sketchSize))
 	}
@@ -508,7 +508,7 @@ func TestToString1(t *testing.T) {
 
 func printSketch(t *testing.T, size int, items []int64) {
 	var sb strings.Builder
-	fls, err := NewFrequencyLongsSketchWithMaxMapSize(size)
+	fls, err := NewLongsSketchWithMaxMapSize(size)
 	assert.NoError(t, err)
 	for i := 0; i < len(items); i++ {
 		fls.UpdateMany(int64(i+1), items[i])
@@ -522,7 +522,7 @@ func printSketch(t *testing.T, size int, items []int64) {
 	fmt.Println("")
 }
 
-func printRows(t *testing.T, fls *FrequencyLongsSketch, errorType errorType) {
+func printRows(t *testing.T, fls *LongsSketch, errorType errorType) {
 	rows, err := fls.GetFrequentItems(errorType)
 	assert.NoError(t, err)
 	fmt.Println(errorType.Name)
@@ -543,7 +543,7 @@ func TestStringDeserEmptyNotCorrupt(t *testing.T) {
 	size := 1 << _LG_MIN_MAP_SIZE
 	thresh := (size * 3) / 4
 	format := "%6d%10s%s"
-	fls, err := NewFrequencyLongsSketchWithMaxMapSize(size)
+	fls, err := NewLongsSketchWithMaxMapSize(size)
 	assert.NoError(t, err)
 	fmt.Printf("Sketch Size: %d\n", size)
 	for i := 0; i <= thresh; i++ {
@@ -552,7 +552,7 @@ func TestStringDeserEmptyNotCorrupt(t *testing.T) {
 		s, err := fls.ToString()
 		assert.NoError(t, err)
 		fmt.Printf("SER   "+format+"\n", (i + 1), fmt.Sprintf("%t : ", fls.IsEmpty()), s)
-		fls2, err := NewFrequencyLongsSketchFromString(s)
+		fls2, err := NewLongsSketchFromString(s)
 		assert.NoError(t, err)
 		fmt.Printf("DESER "+format+"\n", (i + 1), fmt.Sprintf("%t : ", fls2.IsEmpty()), s)
 	}
@@ -568,7 +568,7 @@ func TestStringDeserEmptyCorrupt(t *testing.T) {
 	s.WriteString("1,")  //error offset
 	s.WriteString("0,")  //numActive ...conflict with empty
 	s.WriteString("8,")  //curMapLen
-	_, err := NewFrequencyLongsSketchFromString(s.String())
+	_, err := NewLongsSketchFromString(s.String())
 	assert.Error(t, err)
 }
 
@@ -589,7 +589,7 @@ func TestGetAprioriError(t *testing.T) {
 }
 
 func BenchmarkLongSketch(b *testing.B) {
-	sketch, err := NewFrequencyLongsSketch(128, 8)
+	sketch, err := NewLongsSketch(128, 8)
 	assert.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		sketch.Update(int64(i))

--- a/frequencies/reverse_purge_item_hash_map.go
+++ b/frequencies/reverse_purge_item_hash_map.go
@@ -30,7 +30,7 @@ type reversePurgeItemHashMap[C comparable] struct {
 	values        []int64
 	states        []int16
 	numActive     int
-	hasher        ItemSketchHasher[C]
+	hasher        ItemSketchOp[C]
 }
 
 type iteratorItemHashMap[C comparable] struct {
@@ -56,7 +56,7 @@ const (
 //   - mapSize, This determines the number of cells in the arrays underlying the
 //     HashMap implementation and must be a power of 2.
 //     The hashFn table will be expected to store reversePurgeItemHashMapLoadFactor * mapSize (key, value) pairs.
-func newReversePurgeItemHashMap[C comparable](mapSize int, hasher ItemSketchHasher[C]) (*reversePurgeItemHashMap[C], error) {
+func newReversePurgeItemHashMap[C comparable](mapSize int, hasher ItemSketchOp[C]) (*reversePurgeItemHashMap[C], error) {
 	lgLength, err := internal.ExactLog2(mapSize)
 	if err != nil {
 		return nil, err

--- a/frequencies/reverse_purge_item_hash_map.go
+++ b/frequencies/reverse_purge_item_hash_map.go
@@ -30,7 +30,7 @@ type reversePurgeItemHashMap[C comparable] struct {
 	values        []int64
 	states        []int16
 	numActive     int
-	operations    ItemSketchOp[C]
+	operations    FrequencyItemSketchOp[C]
 }
 
 type iteratorItemHashMap[C comparable] struct {
@@ -56,7 +56,7 @@ const (
 //   - mapSize, This determines the number of cells in the arrays underlying the
 //     HashMap implementation and must be a power of 2.
 //     The hashFn table will be expected to store reversePurgeItemHashMapLoadFactor * mapSize (key, value) pairs.
-func newReversePurgeItemHashMap[C comparable](mapSize int, operations ItemSketchOp[C]) (*reversePurgeItemHashMap[C], error) {
+func newReversePurgeItemHashMap[C comparable](mapSize int, operations FrequencyItemSketchOp[C]) (*reversePurgeItemHashMap[C], error) {
 	lgLength, err := internal.ExactLog2(mapSize)
 	if err != nil {
 		return nil, err

--- a/frequencies/reverse_purge_item_hash_map.go
+++ b/frequencies/reverse_purge_item_hash_map.go
@@ -29,7 +29,7 @@ type reversePurgeItemHashMap[C comparable] struct {
 	values        []int64
 	states        []int16
 	numActive     int
-	hasher        ItemHasher[C]
+	hasher        ItemSketchHasher[C]
 }
 
 const (
@@ -44,7 +44,7 @@ const (
 //   - mapSize, This determines the number of cells in the arrays underlying the
 //     HashMap implementation and must be a power of 2.
 //     The hashFn table will be expected to store reversePurgeItemHashMapLoadFactor * mapSize (key, value) pairs.
-func newReversePurgeItemHashMap[C comparable](mapSize int, hasher ItemHasher[C]) (*reversePurgeItemHashMap[C], error) {
+func newReversePurgeItemHashMap[C comparable](mapSize int, hasher ItemSketchHasher[C]) (*reversePurgeItemHashMap[C], error) {
 	lgLength, err := internal.ExactLog2(mapSize)
 	if err != nil {
 		return nil, err

--- a/frequencies/reverse_purge_item_hash_map.go
+++ b/frequencies/reverse_purge_item_hash_map.go
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package frequencies
+
+import (
+	"fmt"
+	"github.com/apache/datasketches-go/internal"
+)
+
+type reversePurgeItemHashMap[C comparable] struct {
+	lgLength      int
+	loadThreshold int
+	keys          []C
+	values        []int64
+	states        []int16
+	numActive     int
+	hasher        ItemHasher[C]
+}
+
+const (
+	reversePurgeItemHashMapLoadFactor = float64(0.75)
+)
+
+// newReversePurgeItemHashMap will create arrays of length mapSize, which must be a power of two.
+// This restriction was made to ensure fast hashing.
+// The variable this.loadThreshold is then set to the largest value that
+// will not overload the hashFn table.
+//
+//   - mapSize, This determines the number of cells in the arrays underlying the
+//     HashMap implementation and must be a power of 2.
+//     The hashFn table will be expected to store reversePurgeItemHashMapLoadFactor * mapSize (key, value) pairs.
+func newReversePurgeItemHashMap[C comparable](mapSize int, hasher ItemHasher[C]) (*reversePurgeItemHashMap[C], error) {
+	lgLength, err := internal.ExactLog2(mapSize)
+	if err != nil {
+		return nil, err
+	}
+	return &reversePurgeItemHashMap[C]{
+		lgLength,
+		int(float64(mapSize) * reversePurgeItemHashMapLoadFactor),
+		make([]C, mapSize),
+		make([]int64, mapSize),
+		make([]int16, mapSize),
+		0,
+		hasher,
+	}, nil
+}
+
+func (r *reversePurgeItemHashMap[C]) getCapacity() int {
+	return r.loadThreshold
+}
+
+func (r *reversePurgeItemHashMap[C]) get(key C) (int64, error) {
+	//if key == nil {
+	//	return 0, nil
+	//}
+	probe := r.hashProbe(key)
+	if r.states[probe] > 0 {
+		if r.keys[probe] != key {
+			return 0, fmt.Errorf("key not found")
+		}
+		return r.values[probe], nil
+
+	}
+	return 0, nil
+}
+
+func (r *reversePurgeItemHashMap[C]) hashProbe(key C) int {
+	arrayMask := uint64(len(r.keys) - 1)
+
+	probe := r.hasher.Hash(key) & arrayMask
+	for r.states[probe] > 0 && r.keys[probe] != key {
+		probe = probe + 1&arrayMask
+	}
+	return int(probe)
+}

--- a/frequencies/reverse_purge_item_hash_map.go
+++ b/frequencies/reverse_purge_item_hash_map.go
@@ -100,11 +100,14 @@ func (r *reversePurgeItemHashMap[C]) getCapacity() int {
 // key the key of the value to increment
 // adjustAmount the amount by which to increment the value
 func (r *reversePurgeItemHashMap[C]) adjustOrPutValue(key C, adjustAmount int64) error {
-	arrayMask := len(r.keys) - 1
-	probe := int(r.operations.Hash(key) & uint64(arrayMask))
-	drift := 1
+	var (
+		arrayMask = len(r.keys) - 1
+		probe     = r.operations.Hash(key) & uint64(arrayMask)
+		drift     = 1
+	)
+
 	for r.states[probe] != 0 && r.keys[probe] != key {
-		probe = (probe + 1) & arrayMask
+		probe = (probe + 1) & uint64(arrayMask)
 		drift++
 		//only used for theoretical analysis
 		//assert drift < DRIFT_LIMIT : "drift: " + drift + " >= DRIFT_LIMIT";

--- a/frequencies/reverse_purge_item_hash_map.go
+++ b/frequencies/reverse_purge_item_hash_map.go
@@ -30,7 +30,7 @@ type reversePurgeItemHashMap[C comparable] struct {
 	values        []int64
 	states        []int16
 	numActive     int
-	operations    FrequencyItemSketchOp[C]
+	operations    ItemSketchOp[C]
 }
 
 type iteratorItemHashMap[C comparable] struct {
@@ -56,7 +56,7 @@ const (
 //   - mapSize, This determines the number of cells in the arrays underlying the
 //     HashMap implementation and must be a power of 2.
 //     The hashFn table will be expected to store reversePurgeItemHashMapLoadFactor * mapSize (key, value) pairs.
-func newReversePurgeItemHashMap[C comparable](mapSize int, operations FrequencyItemSketchOp[C]) (*reversePurgeItemHashMap[C], error) {
+func newReversePurgeItemHashMap[C comparable](mapSize int, operations ItemSketchOp[C]) (*reversePurgeItemHashMap[C], error) {
 	lgLength, err := internal.ExactLog2(mapSize)
 	if err != nil {
 		return nil, err

--- a/frequencies/reverse_purge_item_hash_map.go
+++ b/frequencies/reverse_purge_item_hash_map.go
@@ -108,7 +108,7 @@ func (r *reversePurgeItemHashMap[C]) hashProbe(key C) int {
 
 func (r *reversePurgeItemHashMap[C]) adjustOrPutValue(key C, adjustAmount int64) error {
 	arrayMask := len(r.keys) - 1
-	probe := r.hashProbe(key) & arrayMask
+	probe := int(r.hasher.Hash(key) & uint64(arrayMask))
 	drift := 1
 	for r.states[probe] != 0 && r.keys[probe] != key {
 		probe = (probe + 1) & arrayMask
@@ -119,7 +119,7 @@ func (r *reversePurgeItemHashMap[C]) adjustOrPutValue(key C, adjustAmount int64)
 
 	if r.states[probe] == 0 {
 		// adding the key to the table the value
-		if r.numActive >= r.loadThreshold {
+		if r.numActive > r.loadThreshold {
 			return fmt.Errorf("numActive: %d >= loadThreshold: %d", r.numActive, r.loadThreshold)
 		}
 		r.keys[probe] = key

--- a/frequencies/reverse_purge_item_hash_map.go
+++ b/frequencies/reverse_purge_item_hash_map.go
@@ -168,8 +168,16 @@ func (r *reversePurgeItemHashMap[C]) purge(sampleSize int) int64 {
 	return val
 }
 
-// TODO
-// serializeToString
+func (r *reversePurgeItemHashMap[C]) serializeToString() string {
+	var sb strings.Builder
+	sb.WriteString(fmt.Sprintf("%d,%d,", r.numActive, len(r.keys)))
+	for i := 0; i < len(r.keys); i++ {
+		if r.states[i] != 0 {
+			sb.WriteString(fmt.Sprintf("%v,%d,", r.keys[i], r.values[i]))
+		}
+	}
+	return sb.String()
+}
 
 // adjustAllValuesBy adjust amount value by which to shift all values. Only keys corresponding to positive
 // values are retained.
@@ -233,10 +241,6 @@ func (r *reversePurgeItemHashMap[C]) hashDelete(deleteProbe int) {
 		//assert drift < DRIFT_LIMIT : "drift: " + drift + " >= DRIFT_LIMIT";
 	}
 }
-
-// TODO
-// deserializeReversePurgeItemHashMapFromString
-// deserializeFromStringArray
 
 func (r *reversePurgeItemHashMap[C]) getActiveValues() []int64 {
 	if r.numActive == 0 {

--- a/frequencies/reverse_purge_long_hash_map.go
+++ b/frequencies/reverse_purge_long_hash_map.go
@@ -305,40 +305,30 @@ func deserializeFromStringArray(tokens []string) (*reversePurgeLongHashMap, erro
 	return hashMap, nil
 }
 
-func (r *reversePurgeLongHashMap) getActiveValues() ([]int64, error) {
+func (r *reversePurgeLongHashMap) getActiveValues() []int64 {
 	if r.numActive == 0 {
-		return nil, nil
+		return nil
 	}
-	returnValues := make([]int64, r.numActive)
-	j := 0
+	returnValues := make([]int64, 0, r.numActive)
 	for i := 0; i < len(r.values); i++ {
 		if r.states[i] > 0 { //isActive
-			returnValues[j] = r.values[i]
-			j++
+			returnValues = append(returnValues, r.values[i])
 		}
 	}
-	if j != r.numActive {
-		return nil, errors.New("j != r.numActive")
-	}
-	return returnValues, nil
+	return returnValues
 }
 
-func (r *reversePurgeLongHashMap) getActiveKeys() ([]int64, error) {
+func (r *reversePurgeLongHashMap) getActiveKeys() []int64 {
 	if r.numActive == 0 {
-		return nil, nil
+		return nil
 	}
-	returnValues := make([]int64, r.numActive)
-	j := 0
+	returnValues := make([]int64, 0, r.numActive)
 	for i := 0; i < len(r.keys); i++ {
 		if r.states[i] > 0 { //isActive
-			returnValues[j] = r.keys[i]
-			j++
+			returnValues = append(returnValues, r.keys[i])
 		}
 	}
-	if j != r.numActive {
-		return nil, errors.New("j != r.numActive")
-	}
-	return returnValues, nil
+	return returnValues
 }
 
 func (s *reversePurgeLongHashMap) iterator() *iteratorLongHashMap {

--- a/frequencies/reverse_purge_long_hash_map.go
+++ b/frequencies/reverse_purge_long_hash_map.go
@@ -36,7 +36,7 @@ type reversePurgeLongHashMap struct {
 	numActive     int
 }
 
-type iteratorHashMap struct {
+type iteratorLongHashMap struct {
 	keys_      []int64
 	values_    []int64
 	states_    []int16
@@ -341,8 +341,8 @@ func (r *reversePurgeLongHashMap) getActiveKeys() ([]int64, error) {
 	return returnValues, nil
 }
 
-func (s *reversePurgeLongHashMap) iterator() *iteratorHashMap {
-	return newIterator(s.keys, s.values, s.states, s.numActive)
+func (s *reversePurgeLongHashMap) iterator() *iteratorLongHashMap {
+	return newIteratorLong(s.keys, s.values, s.states, s.numActive)
 }
 
 func (s *reversePurgeLongHashMap) hashProbe(key int64) int {
@@ -367,9 +367,9 @@ func (s *reversePurgeLongHashMap) String() string {
 	return sb.String()
 }
 
-func newIterator(keys []int64, values []int64, states []int16, numActive int) *iteratorHashMap {
+func newIteratorLong(keys []int64, values []int64, states []int16, numActive int) *iteratorLongHashMap {
 	stride := int(uint64(float64(len(keys))*internal.InverseGolden) | 1)
-	return &iteratorHashMap{
+	return &iteratorLongHashMap{
 		keys_:      keys,
 		values_:    values,
 		states_:    states,
@@ -381,7 +381,7 @@ func newIterator(keys []int64, values []int64, states []int16, numActive int) *i
 	}
 }
 
-func (i *iteratorHashMap) next() bool {
+func (i *iteratorLongHashMap) next() bool {
 	i.i_ = (i.i_ + i.stride_) & i.mask_
 	for i.count_ < i.numActive_ {
 		if i.states_[i.i_] > 0 {
@@ -393,10 +393,10 @@ func (i *iteratorHashMap) next() bool {
 	return false
 }
 
-func (i *iteratorHashMap) getKey() int64 {
+func (i *iteratorLongHashMap) getKey() int64 {
 	return i.keys_[i.i_]
 }
 
-func (i *iteratorHashMap) getValue() int64 {
+func (i *iteratorLongHashMap) getValue() int64 {
 	return i.values_[i.i_]
 }

--- a/frequencies/reverse_purge_long_hash_map.go
+++ b/frequencies/reverse_purge_long_hash_map.go
@@ -56,7 +56,7 @@ const (
 // It will create arrays of length mapSize, which must be a power of two.
 // This restriction was made to ensure fast hashing.
 // The member loadThreshold is then set to the largest value that
-// will not overload the hash table.
+// will not overload the hashFn table.
 func newReversePurgeLongHashMap(mapSize int) (*reversePurgeLongHashMap, error) {
 	lgLength, err := internal.ExactLog2(mapSize)
 	if err != nil {
@@ -86,7 +86,7 @@ func (r *reversePurgeLongHashMap) get(key int64) (int64, error) {
 	return 0, nil
 }
 
-// getCapacity returns the current capacity of the hash map (i.e., max number of keys that can be stored).
+// getCapacity returns the current capacity of the hashFn map (i.e., max number of keys that can be stored).
 func (r *reversePurgeLongHashMap) getCapacity() int {
 	return r.loadThreshold
 }
@@ -100,7 +100,7 @@ func (r *reversePurgeLongHashMap) getCapacity() int {
 func (r *reversePurgeLongHashMap) adjustOrPutValue(key int64, adjustAmount int64) error {
 	var (
 		arrayMask = len(r.keys) - 1
-		probe     = hash(key) & int64(arrayMask)
+		probe     = hashFn(key) & int64(arrayMask)
 		drift     = 1
 	)
 	for r.states[probe] != 0 && r.keys[probe] != key {
@@ -347,7 +347,7 @@ func (s *reversePurgeLongHashMap) iterator() *iteratorHashMap {
 
 func (s *reversePurgeLongHashMap) hashProbe(key int64) int {
 	arrayMask := len(s.keys) - 1
-	probe := int(hash(key)) & arrayMask
+	probe := int(hashFn(key)) & arrayMask
 	for s.states[probe] > 0 && s.keys[probe] != key {
 		probe = (probe + 1) & arrayMask
 	}

--- a/frequencies/serde_compat_test.go
+++ b/frequencies/serde_compat_test.go
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package frequencies
+
+import (
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestItemsToLongs(t *testing.T) {
+	sketch1, err := NewItemsSketchWithMaxMapSize[int64](8, IntItemsSketchOp{})
+	assert.NoError(t, err)
+	sketch1.Update(1)
+	sketch1.Update(2)
+	sketch1.Update(3)
+	sketch1.Update(4)
+
+	bytes := sketch1.ToSlice()
+	sketch2, err := NewLongsSketchFromSlice(bytes)
+	assert.NoError(t, err)
+	sketch2.Update(2)
+	sketch2.Update(3)
+	sketch2.Update(2)
+
+	assert.False(t, sketch2.IsEmpty())
+	assert.Equal(t, sketch2.GetNumActiveItems(), 4)
+	assert.Equal(t, sketch2.GetStreamLength(), int64(7))
+	est, err := sketch2.GetEstimate(1)
+	assert.NoError(t, err)
+	assert.Equal(t, est, int64(1))
+	est, err = sketch2.GetEstimate(2)
+	assert.NoError(t, err)
+	assert.Equal(t, est, int64(3))
+	est, err = sketch2.GetEstimate(3)
+	assert.NoError(t, err)
+	assert.Equal(t, est, int64(2))
+	est, err = sketch2.GetEstimate(4)
+	assert.NoError(t, err)
+	assert.Equal(t, est, int64(1))
+}
+
+func TestLongToItems(t *testing.T) {
+	sketch1, err := NewLongsSketchWithMaxMapSize(8)
+	assert.NoError(t, err)
+	sketch1.Update(1)
+	sketch1.Update(2)
+	sketch1.Update(3)
+	sketch1.Update(4)
+
+	bytes := sketch1.ToSlice()
+	sketch2, err := NewItemsSketchFromSlice[int64](bytes, IntItemsSketchOp{})
+	assert.NoError(t, err)
+	sketch2.Update(2)
+	sketch2.Update(3)
+	sketch2.Update(2)
+
+	assert.False(t, sketch2.IsEmpty())
+	assert.Equal(t, sketch2.GetNumActiveItems(), 4)
+	assert.Equal(t, sketch2.GetStreamLength(), int64(7))
+	est, err := sketch2.GetEstimate(1)
+	assert.NoError(t, err)
+	assert.Equal(t, est, int64(1))
+	est, err = sketch2.GetEstimate(2)
+	assert.NoError(t, err)
+	assert.Equal(t, est, int64(3))
+	est, err = sketch2.GetEstimate(3)
+	assert.NoError(t, err)
+	assert.Equal(t, est, int64(2))
+	est, err = sketch2.GetEstimate(4)
+	assert.NoError(t, err)
+	assert.Equal(t, est, int64(1))
+}

--- a/frequencies/utils.go
+++ b/frequencies/utils.go
@@ -23,8 +23,10 @@ import (
 )
 
 const (
+	// _LG_MIN_MAP_SIZE constant controle the size of the initial data structure for the
+	// frequencies sketches and its value is somewhat arbitrary.
 	_LG_MIN_MAP_SIZE = 3
-	// This constant is large enough so that computing the median of SAMPLE_SIZE
+	// _SAMPLE_SIZE constant is large enough so that computing the median of SAMPLE_SIZE
 	// randomly selected entries from a list of numbers and outputting
 	// the empirical median will give a constant-factor approximation to the
 	// true median with high probability.
@@ -52,10 +54,14 @@ var ErrorTypeEnum = &errorTypes{
 	},
 }
 
-// hash returns an index into the hash table.
-// This hash function is taken from the internals of Austin Appleby's MurmurHash3 algorithm.
+type ItemHasher[C comparable] interface {
+	Hash(item C) uint64
+}
+
+// hashFn returns an index into the hashFn table.
+// This hashFn function is taken from the internals of Austin Appleby's MurmurHash3 algorithm.
 // It is also used by the Trove for Java libraries.
-func hash(okey int64) int64 {
+func hashFn(okey int64) int64 {
 	key := uint64(okey)
 	key ^= key >> 33
 	key *= 0xff51afd7ed558ccd

--- a/frequencies/utils.go
+++ b/frequencies/utils.go
@@ -54,10 +54,6 @@ var ErrorTypeEnum = &errorTypes{
 	},
 }
 
-type ItemHasher[C comparable] interface {
-	Hash(item C) uint64
-}
-
 // hashFn returns an index into the hashFn table.
 // This hashFn function is taken from the internals of Austin Appleby's MurmurHash3 algorithm.
 // It is also used by the Trove for Java libraries.

--- a/frequencies/utils.go
+++ b/frequencies/utils.go
@@ -20,6 +20,7 @@ package frequencies
 import (
 	"math"
 	"math/rand"
+	"reflect"
 )
 
 const (
@@ -65,6 +66,19 @@ func hashFn(okey int64) int64 {
 	key *= 0xc4ceb9fe1a85ec53
 	key ^= key >> 33
 	return int64(key)
+}
+
+func isNil[T any](t T) bool {
+	v := reflect.ValueOf(t)
+	kind := v.Kind()
+	// Must be one of these types to be nillable
+	return (kind == reflect.Ptr ||
+		kind == reflect.Interface ||
+		kind == reflect.Slice ||
+		kind == reflect.Map ||
+		kind == reflect.Chan ||
+		kind == reflect.Func) &&
+		v.IsNil()
 }
 
 func randomGeometricDist(prob float64) int64 {


### PR DESCRIPTION
Add the implementation of the Frequency Item Sketch for arbitrary types using generics.

This also test for compatibility to go back and forth with the frequency LongSketch

performance wise it does take a hit compared to LongSketch, but is probably manageable.



```
pkg: github.com/apache/datasketches-go/frequencies
BenchmarkLongSketch
BenchmarkLongSketch-10-lgMapMax-128   	24445705	        95.53 ns/op
PASS

pkg: github.com/apache/datasketches-go/frequencies
BenchmarkLongSketch
BenchmarkLongSketch-10-lgMapMax-10    	47026702	        21.29 ns/op
PASS
```

```
pkg: github.com/apache/datasketches-go/frequencies
BenchmarkItemSketch
BenchmarkItemSketch-10-lgMapMax-128    	14984071	       140.3 ns/op
PASS

pkg: github.com/apache/datasketches-go/frequencies
BenchmarkItemSketch
BenchmarkItemSketch-10-lgMapMax-10   	34768750	        33.51 ns/op
PASS
```



