### PR TITLE
Refactored common SerDe, Example and KLL doc

### DIFF
--- a/common/array_of_longs_serde.go
+++ b/common/array_of_longs_serde.go
@@ -1,0 +1,81 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"encoding/binary"
+	"github.com/twmb/murmur3"
+)
+
+type ArrayOfLongsSerDe struct {
+	scratch [8]byte
+}
+
+func (f ArrayOfLongsSerDe) Identity() int64 {
+	return 0
+}
+
+func (f ArrayOfLongsSerDe) Hash(item int64) uint64 {
+	binary.LittleEndian.PutUint64(f.scratch[:], uint64(item))
+	return murmur3.SeedSum64(_DEFAULT_SERDE_HASH_SEED, f.scratch[:])
+}
+
+func (f ArrayOfLongsSerDe) LessFn() LessFn[int64] {
+	return func(a int64, b int64) bool {
+		return a < b
+	}
+}
+
+func (f ArrayOfLongsSerDe) SizeOf(item int64) int {
+	return 8
+}
+
+func (f ArrayOfLongsSerDe) SizeOfMany(mem []byte, offsetBytes int, numItems int) (int, error) {
+	return numItems * 8, nil
+}
+
+func (f ArrayOfLongsSerDe) SerializeOneToSlice(item int64) []byte {
+	bytes := make([]byte, 8)
+	binary.LittleEndian.PutUint64(bytes, uint64(item))
+	return bytes
+}
+
+func (f ArrayOfLongsSerDe) SerializeManyToSlice(item []int64) []byte {
+	if len(item) == 0 {
+		return []byte{}
+	}
+	bytes := make([]byte, 8*len(item))
+	offset := 0
+	for i := 0; i < len(item); i++ {
+		binary.LittleEndian.PutUint64(bytes[offset:], uint64(item[i]))
+		offset += 8
+	}
+	return bytes
+}
+
+func (f ArrayOfLongsSerDe) DeserializeManyFromSlice(mem []byte, offsetBytes int, numItems int) ([]int64, error) {
+	if numItems == 0 {
+		return []int64{}, nil
+	}
+	array := make([]int64, 0, numItems)
+	for i := 0; i < numItems; i++ {
+		array = append(array, int64(binary.LittleEndian.Uint64(mem[offsetBytes:])))
+		offsetBytes += 8
+	}
+	return array, nil
+}

--- a/common/array_of_strings_serde.go
+++ b/common/array_of_strings_serde.go
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package common
+
+import (
+	"encoding/binary"
+	"errors"
+	"unsafe"
+
+	"github.com/twmb/murmur3"
+)
+
+type ArrayOfStringsSerDe struct {
+}
+
+func (f ArrayOfStringsSerDe) Identity() string {
+	return ""
+}
+
+func (f ArrayOfStringsSerDe) Hash(item string) uint64 {
+	datum := unsafe.Slice(unsafe.StringData(item), len(item))
+	return murmur3.SeedSum64(_DEFAULT_SERDE_HASH_SEED, datum[:])
+}
+
+func (f ArrayOfStringsSerDe) LessFn() LessFn[string] {
+	return func(a string, b string) bool {
+		return a < b
+	}
+}
+
+func (f ArrayOfStringsSerDe) SizeOf(item string) int {
+	if len(item) == 0 {
+		return int(unsafe.Sizeof(uint32(0)))
+	}
+	return len(item) + int(unsafe.Sizeof(uint32(0)))
+}
+
+func (f ArrayOfStringsSerDe) SizeOfMany(mem []byte, offsetBytes int, numItems int) (int, error) {
+	if numItems <= 0 {
+		return 0, nil
+	}
+	reqLen := 4
+	offset := offsetBytes
+	memCap := len(mem)
+	for i := 0; i < numItems; i++ {
+		if !checkBounds(offset, reqLen, memCap) {
+			return 0, errors.New("offset out of bounds")
+		}
+		itemLenBytes := int(binary.LittleEndian.Uint32(mem[offset:]))
+		offset += 4
+		if offset+itemLenBytes > memCap {
+			return 0, errors.New("offset out of bounds")
+		}
+		offset += itemLenBytes
+	}
+	return offset - offsetBytes, nil
+}
+
+func (f ArrayOfStringsSerDe) SerializeOneToSlice(item string) []byte {
+	if len(item) == 0 {
+		return []byte{}
+	}
+	utf8len := len(item)
+	bytesOut := make([]byte, utf8len+4)
+	binary.LittleEndian.PutUint32(bytesOut, uint32(utf8len))
+	copy(bytesOut[4:], []byte(item))
+	return bytesOut
+}
+
+func (f ArrayOfStringsSerDe) SerializeManyToSlice(item []string) []byte {
+	if len(item) == 0 {
+		return []byte{}
+	}
+	totalBytes := 0
+	numItems := len(item)
+	serialized2DArray := make([][]byte, numItems)
+	for i := 0; i < numItems; i++ {
+		serialized2DArray[i] = []byte(item[i])
+		totalBytes += len(serialized2DArray[i]) + 4
+	}
+	bytesOut := make([]byte, totalBytes)
+	offset := 0
+	for i := 0; i < numItems; i++ {
+		utf8len := len(serialized2DArray[i])
+		binary.LittleEndian.PutUint32(bytesOut[offset:], uint32(utf8len))
+		offset += 4
+		copy(bytesOut[offset:], serialized2DArray[i])
+		offset += utf8len
+	}
+	return bytesOut
+}
+
+func (f ArrayOfStringsSerDe) DeserializeManyFromSlice(mem []byte, offsetBytes int, numItems int) ([]string, error) {
+	if numItems <= 0 {
+		return []string{}, nil
+	}
+	array := make([]string, numItems)
+	offset := offsetBytes
+	intSize := int(unsafe.Sizeof(uint32(0)))
+	memCap := len(mem)
+	for i := 0; i < numItems; i++ {
+		if !checkBounds(offset, intSize, memCap) {
+			return nil, errors.New("offset out of bounds")
+		}
+		strLength := int(binary.LittleEndian.Uint32(mem[offset:]))
+		offset += intSize
+		utf8Bytes := make([]byte, strLength)
+		if !checkBounds(offset, strLength, memCap) {
+			return nil, errors.New("offset out of bounds")
+		}
+		copy(utf8Bytes, mem[offset:offset+strLength])
+		offset += strLength
+		array[i] = string(utf8Bytes)
+	}
+	return array, nil
+}

--- a/common/utils.go
+++ b/common/utils.go
@@ -17,15 +17,10 @@
 
 package common
 
-type LessFn[C comparable] func(C, C) bool
+const (
+	_DEFAULT_SERDE_HASH_SEED = uint64(9001)
+)
 
-type ItemSketchOp[C comparable] interface {
-	Identity() C
-	Hash(item C) uint64
-	LessFn() LessFn[C]
-	SizeOf(item C) int
-	SizeOfMany(mem []byte, offsetBytes int, numItems int) (int, error)
-	SerializeManyToSlice(items []C) []byte
-	SerializeOneToSlice(item C) []byte
-	DeserializeManyFromSlice(mem []byte, offsetBytes int, numItems int) ([]C, error)
+func checkBounds(offset int, reqLen int, memCap int) bool {
+	return !((offset | reqLen | (offset + reqLen) | (memCap - (offset + reqLen))) < 0)
 }

--- a/examples/frequency_example_test.go
+++ b/examples/frequency_example_test.go
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package examples
+
+import (
+	"github.com/apache/datasketches-go/common"
+	"github.com/apache/datasketches-go/frequencies"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFrequencyItemsSketch(t *testing.T) {
+	// Create a new sketch with a maximum of 16 items
+	sketch, err := frequencies.NewFrequencyItemsSketchWithMaxMapSize[string](16, common.ArrayOfStringsSerDe{})
+	assert.NoError(t, err)
+
+	// Update the sketch with some items
+	sketch.Update("a")
+	sketch.Update("b")
+	sketch.Update("c")
+	sketch.Update("a")
+	sketch.Update("b")
+	sketch.Update("a")
+	sketch.Update("d")
+	sketch.Update("a")
+	sketch.Update("b")
+	sketch.Update("c")
+	sketch.Update("a")
+	sketch.Update("b")
+	sketch.Update("c")
+	sketch.Update("a")
+	sketch.Update("b")
+	sketch.Update("c")
+	sketch.Update("a")
+	sketch.Update("b")
+	sketch.Update("c")
+	sketch.Update("a")
+	sketch.Update("b")
+	sketch.Update("c")
+	sketch.Update("a")
+	sketch.Update("b")
+	sketch.Update("c")
+
+	// Get the frequent items
+	frequentItems, err := sketch.GetFrequentItems(frequencies.ErrorTypeEnum.NoFalsePositives)
+	assert.NoError(t, err)
+	assert.Equal(t, 4, len(frequentItems))
+	assert.Equal(t, "a", frequentItems[0].GetItem())
+	assert.Equal(t, "b", frequentItems[1].GetItem())
+	assert.Equal(t, "c", frequentItems[2].GetItem())
+	assert.Equal(t, "d", frequentItems[3].GetItem())
+
+	// Get the estimates
+	assert.Equal(t, int64(9), frequentItems[0].GetEstimate())
+	assert.Equal(t, int64(8), frequentItems[1].GetEstimate())
+	assert.Equal(t, int64(7), frequentItems[2].GetEstimate())
+	assert.Equal(t, int64(1), frequentItems[3].GetEstimate())
+
+	// Get the lower bounds
+	assert.Equal(t, int64(9), frequentItems[0].GetLowerBound())
+	assert.Equal(t, int64(8), frequentItems[1].GetLowerBound())
+	assert.Equal(t, int64(7), frequentItems[2].GetLowerBound())
+	assert.Equal(t, int64(1), frequentItems[3].GetLowerBound())
+
+	// Get the upper bounds
+	assert.Equal(t, int64(9), frequentItems[0].GetUpperBound())
+	assert.Equal(t, int64(8), frequentItems[1].GetUpperBound())
+	assert.Equal(t, int64(7), frequentItems[2].GetUpperBound())
+	assert.Equal(t, int64(1), frequentItems[3].GetUpperBound())
+}

--- a/examples/hll_example_test.go
+++ b/examples/hll_example_test.go
@@ -15,17 +15,29 @@
  * limitations under the License.
  */
 
-package common
+package examples
 
-type LessFn[C comparable] func(C, C) bool
+import (
+	"fmt"
+	"github.com/apache/datasketches-go/hll"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
 
-type ItemSketchOp[C comparable] interface {
-	Identity() C
-	Hash(item C) uint64
-	LessFn() LessFn[C]
-	SizeOf(item C) int
-	SizeOfMany(mem []byte, offsetBytes int, numItems int) (int, error)
-	SerializeManyToSlice(items []C) []byte
-	SerializeOneToSlice(item C) []byte
-	DeserializeManyFromSlice(mem []byte, offsetBytes int, numItems int) ([]C, error)
+func TestHllItemsSketch(t *testing.T) {
+	// Create a new KLL sketch
+	sketch, err := hll.NewHllSketchWithDefault()
+	assert.NoError(t, err)
+
+	// Update the sketch with 1000 items
+	for i := 0; i < 1000; i++ {
+		err := sketch.UpdateString(fmt.Sprintf("item_%d", i))
+		assert.NoError(t, err)
+	}
+
+	// Get the estimate of the number of unique items
+	estimate, err := sketch.GetEstimate()
+	assert.NoError(t, err)
+	assert.Greater(t, estimate, 900)
+	assert.Less(t, estimate, 1100)
 }

--- a/examples/kll_example_test.go
+++ b/examples/kll_example_test.go
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package examples
+
+import (
+	"fmt"
+	"github.com/apache/datasketches-go/common"
+	"github.com/apache/datasketches-go/kll"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestKllItemsSketch(t *testing.T) {
+	// Create a new KLL sketch
+	sketch, err := kll.NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+	assert.NoError(t, err)
+
+	// Update the sketch with 1000 items
+	for i := 0; i < 1000; i++ {
+		sketch.Update(fmt.Sprintf("item_%d", i))
+	}
+
+	// Get the quantiles
+	quantiles := []float64{0.0, 0.5, 1.0}
+	values, err := sketch.GetQuantiles(quantiles, true)
+	assert.NoError(t, err)
+
+	// Validate the quantiles
+	assert.Equal(t, "item_0", values[0])
+	assert.Equal(t, "item_548", values[1])
+	assert.Equal(t, "item_999", values[2])
+
+	// Get the PMF
+	pmf, err := sketch.GetPMF([]string{"item_0", "item_548", "item_999"}, true)
+	assert.NoError(t, err)
+
+	// Validate the PMF
+	assert.Equal(t, 0.004, pmf[0])
+	assert.Equal(t, 0.498, pmf[1])
+	assert.Equal(t, 0.498, pmf[2])
+
+	// Get the CDF
+	cdf, err := sketch.GetCDF([]string{"item_0", "item_548", "item_999"}, true)
+	assert.NoError(t, err)
+
+	// Validate the CDF
+	assert.Equal(t, 0.004, cdf[0])
+	assert.Equal(t, 0.502, cdf[1])
+	assert.Equal(t, 1.0, cdf[2])
+
+	// Get the rank of an item
+	rank, err := sketch.GetRank("item_548", true)
+	assert.NoError(t, err)
+	assert.Equal(t, 0.502, rank)
+}

--- a/frequencies/items_sketch.go
+++ b/frequencies/items_sketch.go
@@ -53,7 +53,7 @@ type ItemsSketch[C comparable] struct {
 	hashMap *reversePurgeItemHashMap[C]
 }
 
-// NewItemsSketch constructs a new ItemsSketch with the given parameters.
+// NewFrequencyItemsSketch constructs a new ItemsSketch with the given parameters.
 // this internal constructor is used when deserializing the sketch.
 //
 //   - lgMaxMapSize, log2 of the physical size of the internal hash map managed by this
@@ -61,7 +61,7 @@ type ItemsSketch[C comparable] struct {
 //     Both the ultimate accuracy and size of this sketch are functions of lgMaxMapSize.
 //   - lgCurMapSize, log2 of the starting (current) physical size of the internal hashFn
 //     map managed by this sketch.
-func NewItemsSketch[C comparable](lgMaxMapSize int, lgCurMapSize int, operations common.ItemSketchOp[C]) (*ItemsSketch[C], error) {
+func NewFrequencyItemsSketch[C comparable](lgMaxMapSize int, lgCurMapSize int, operations common.ItemSketchOp[C]) (*ItemsSketch[C], error) {
 	lgMaxMapSz := max(lgMaxMapSize, _LG_MIN_MAP_SIZE)
 	lgCurMapSz := max(lgCurMapSize, _LG_MIN_MAP_SIZE)
 	hashMap, err := newReversePurgeItemHashMap[C](1<<lgCurMapSz, operations)
@@ -82,29 +82,29 @@ func NewItemsSketch[C comparable](lgMaxMapSize int, lgCurMapSize int, operations
 	}, nil
 }
 
-// NewItemsSketchWithMaxMapSize constructs a new ItemsSketch with the given maxMapSize and the default
+// NewFrequencyItemsSketchWithMaxMapSize constructs a new ItemsSketch with the given maxMapSize and the default
 // initialMapSize (8).
 //
 //   - maxMapSize, Determines the physical size of the internal hash map managed by this
 //     sketch and must be a power of 2. The maximum capacity of this internal hash map is
 //     0.75 times * maxMapSize. Both the ultimate accuracy and size of this sketch are
 //     functions of maxMapSize.
-func NewItemsSketchWithMaxMapSize[C comparable](maxMapSize int, operations common.ItemSketchOp[C]) (*ItemsSketch[C], error) {
+func NewFrequencyItemsSketchWithMaxMapSize[C comparable](maxMapSize int, operations common.ItemSketchOp[C]) (*ItemsSketch[C], error) {
 	maxMapSz, err := internal.ExactLog2(maxMapSize)
 	if err != nil {
 		return nil, err
 	}
-	return NewItemsSketch[C](maxMapSz, _LG_MIN_MAP_SIZE, operations)
+	return NewFrequencyItemsSketch[C](maxMapSz, _LG_MIN_MAP_SIZE, operations)
 }
 
-// NewItemsSketchFromSlice constructs a new ItemsSketch with the given maxMapSize and the
+// NewFrequencyItemsSketchFromSlice constructs a new ItemsSketch with the given maxMapSize and the
 // default initialMapSize (8).
 //
 // maxMapSize determines the physical size of the internal hashmap managed by this
 // sketch and must be a power of 2.  The maximum capacity of this internal hash map is
 // 0.75 times * maxMapSize. Both the ultimate accuracy and size of this sketch are a
 // function of maxMapSize.
-func NewItemsSketchFromSlice[C comparable](slc []byte, operations common.ItemSketchOp[C]) (*ItemsSketch[C], error) {
+func NewFrequencyItemsSketchFromSlice[C comparable](slc []byte, operations common.ItemSketchOp[C]) (*ItemsSketch[C], error) {
 	pre0, err := checkPreambleSize(slc) //make sure preamble will fit
 	maxPreLongs := internal.FamilyEnum.Frequency.MaxPreLongs
 
@@ -132,7 +132,7 @@ func NewItemsSketchFromSlice[C comparable](slc []byte, operations common.ItemSke
 		return nil, fmt.Errorf("(preLongs == 1) ^ empty == true")
 	}
 	if empty {
-		return NewItemsSketchWithMaxMapSize[C](1<<_LG_MIN_MAP_SIZE, operations)
+		return NewFrequencyItemsSketchWithMaxMapSize[C](1<<_LG_MIN_MAP_SIZE, operations)
 	}
 	// Get full preamble
 	preArr := make([]int64, preLongs)
@@ -140,7 +140,7 @@ func NewItemsSketchFromSlice[C comparable](slc []byte, operations common.ItemSke
 		preArr[j] = int64(binary.LittleEndian.Uint64(slc[j<<3:]))
 	}
 
-	fis, err := NewItemsSketch[C](int(lgMaxMapSize), int(lgCurMapSize), operations)
+	fis, err := NewFrequencyItemsSketch[C](int(lgMaxMapSize), int(lgCurMapSize), operations)
 	if err != nil {
 		return nil, err
 	}
@@ -176,12 +176,12 @@ func NewItemsSketchFromSlice[C comparable](slc []byte, operations common.ItemSke
 	return fis, nil
 }
 
-// GetAprioriErrorItemsSketch returns the estimated a priori error given the maxMapSize for the sketch and the
+// GetAprioriErrorFrequencyItemsSketch returns the estimated a priori error given the maxMapSize for the sketch and the
 // estimatedTotalStreamWeight.
 //
 // maxMapSize is the planned map size to be used when constructing this sketch.
 // estimatedTotalStreamWeight is the estimated total stream weight.
-func GetAprioriErrorItemsSketch(maxMapSize int, estimatedTotalStreamWeight int64) (float64, error) {
+func GetAprioriErrorFrequencyItemsSketch(maxMapSize int, estimatedTotalStreamWeight int64) (float64, error) {
 	epsilon, err := GetEpsilonLongsSketch(maxMapSize)
 	if err != nil {
 		return 0, err
@@ -189,20 +189,20 @@ func GetAprioriErrorItemsSketch(maxMapSize int, estimatedTotalStreamWeight int64
 	return epsilon * float64(estimatedTotalStreamWeight), nil
 }
 
-// GetCurrentMapCapacity returns the current number of counters the sketch is configured to support.
-func (i *ItemsSketch[C]) GetCurrentMapCapacity() int {
-	return i.curMapCap
-}
-
-// GetEpsilonItemsSketch returns epsilon used to compute a priori error.
+// GetEpsilonFrequencyItemsSketch returns epsilon used to compute a priori error.
 // This is just the value 3.5 / maxMapSize.
 //
 // maxMapSize is the planned map size to be used when constructing this sketch.
-func GetEpsilonItemsSketch(maxMapSize int) (float64, error) {
+func GetEpsilonFrequencyItemsSketch(maxMapSize int) (float64, error) {
 	if !internal.IsPowerOf2(maxMapSize) {
 		return 0, errors.New("maxMapSize is not a power of 2")
 	}
 	return 3.5 / float64(maxMapSize), nil
+}
+
+// GetCurrentMapCapacity returns the current number of counters the sketch is configured to support.
+func (i *ItemsSketch[C]) GetCurrentMapCapacity() int {
+	return i.curMapCap
 }
 
 // GetEstimate gets the estimate of the frequency of the given item.

--- a/frequencies/items_sketch_test.go
+++ b/frequencies/items_sketch_test.go
@@ -27,7 +27,7 @@ import (
 
 func TestEmpty(t *testing.T) {
 	h := common.ArrayOfStringsSerDe{}
-	sketch, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, h)
+	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, h)
 	assert.NoError(t, err)
 	assert.True(t, sketch.IsEmpty())
 	assert.Equal(t, sketch.GetNumActiveItems(), 0)
@@ -41,7 +41,7 @@ func TestEmpty(t *testing.T) {
 }
 
 func TestOneItem(t *testing.T) {
-	sketch, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
+	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	err = sketch.Update("a")
 	assert.NoError(t, err)
@@ -57,7 +57,7 @@ func TestOneItem(t *testing.T) {
 }
 
 func TestSeveralItem(t *testing.T) {
-	sketch, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
+	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	err = sketch.Update("a")
 	assert.NoError(t, err)
@@ -106,7 +106,7 @@ func TestSeveralItem(t *testing.T) {
 }
 
 func TestEstimationMode(t *testing.T) {
-	sketch, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
+	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	err = sketch.UpdateMany(1, 10)
 	assert.NoError(t, err)
@@ -166,10 +166,10 @@ func TestEstimationMode(t *testing.T) {
 }
 
 func TestSerializeStringDeserializeEmpty(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	bytes := sketch1.ToSlice()
-	sketch2, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+	sketch2, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	assert.True(t, sketch2.IsEmpty())
 	assert.Equal(t, sketch2.GetNumActiveItems(), 0)
@@ -177,7 +177,7 @@ func TestSerializeStringDeserializeEmpty(t *testing.T) {
 }
 
 func TestSerializeDeserializeUtf8Strings(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	err = sketch1.Update("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	assert.NoError(t, err)
@@ -189,7 +189,7 @@ func TestSerializeDeserializeUtf8Strings(t *testing.T) {
 	assert.NoError(t, err)
 
 	bytes := sketch1.ToSlice()
-	sketch2, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+	sketch2, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	err = sketch2.Update("bbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
 	assert.NoError(t, err)
@@ -216,14 +216,14 @@ func TestSerializeDeserializeUtf8Strings(t *testing.T) {
 }
 
 func TestSerializeDeserializeLong(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
 	sketch1.Update(1)
 	sketch1.Update(2)
 	sketch1.Update(3)
 	sketch1.Update(4)
 
 	bytes := sketch1.ToSlice()
-	sketch2, err := NewItemsSketchFromSlice[int64](bytes, common.ArrayOfLongsSerDe{})
+	sketch2, err := NewFrequencyItemsSketchFromSlice[int64](bytes, common.ArrayOfLongsSerDe{})
 	sketch2.Update(2)
 	sketch2.Update(3)
 	sketch2.Update(2)
@@ -246,7 +246,7 @@ func TestSerializeDeserializeLong(t *testing.T) {
 }
 
 func TestResize(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[string](2<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](2<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
 	for i := 0; i < 32; i++ {
 		err = sketch1.UpdateMany(strconv.Itoa(i), int64(i*i))
 		assert.NoError(t, err)
@@ -254,7 +254,7 @@ func TestResize(t *testing.T) {
 }
 
 func TestMergeExact(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	err = sketch1.Update("a")
 	assert.NoError(t, err)
@@ -265,7 +265,7 @@ func TestMergeExact(t *testing.T) {
 	err = sketch1.Update("d")
 	assert.NoError(t, err)
 
-	sketch2, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
+	sketch2, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	err = sketch2.Update("b")
 	assert.NoError(t, err)
@@ -301,13 +301,13 @@ func TestNullMapReturns(t *testing.T) {
 }
 
 func TestMisc(t *testing.T) {
-	sk1, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
+	sk1, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	assert.Equal(t, sk1.GetCurrentMapCapacity(), 6)
 	est, err := sk1.GetEstimate(1)
 	assert.NoError(t, err)
 	assert.Equal(t, est, int64(0))
-	sk2, err := NewItemsSketchWithMaxMapSize[int64](8, common.ArrayOfLongsSerDe{})
+	sk2, err := NewFrequencyItemsSketchWithMaxMapSize[int64](8, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	_, err = sk1.Merge(sk2)
 	assert.NoError(t, err)
@@ -328,14 +328,14 @@ func TestMisc(t *testing.T) {
 }
 
 func TestToString(t *testing.T) {
-	sk, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
+	sk, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	err = sk.Update(1)
 	t.Log(sk.ToString())
 }
 
 func TestFrequentItems1(t *testing.T) {
-	fis, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
+	fis, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	fis.Update(1)
 	rows, err := fis.GetFrequentItems(ErrorTypeEnum.NoFalsePositives)
@@ -352,14 +352,14 @@ func TestFrequentItems1(t *testing.T) {
 }
 
 func TestUpdateExceptions(t *testing.T) {
-	sk1, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
+	sk1, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	err = sk1.UpdateMany(1, -1)
 	assert.Error(t, err)
 }
 
 func TestMemExceptions(t *testing.T) {
-	sk1, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
+	sk1, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	sk1.Update(1)
 	bytes := sk1.ToSlice()
@@ -379,7 +379,7 @@ func TestMemExceptions(t *testing.T) {
 }
 
 func TestOneItemUtf8(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	err = sketch1.Update("\u5fb5")
 	assert.NoError(t, err)
@@ -391,7 +391,7 @@ func TestOneItemUtf8(t *testing.T) {
 	assert.Equal(t, est, int64(1))
 
 	bytes := sketch1.ToSlice()
-	sketch2, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+	sketch2, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	assert.False(t, sketch2.IsEmpty())
 	assert.Equal(t, sketch2.GetNumActiveItems(), 1)
@@ -402,23 +402,23 @@ func TestOneItemUtf8(t *testing.T) {
 }
 
 func TestItemGetEpsilon(t *testing.T) {
-	esp, err := GetEpsilonItemsSketch(1024)
+	esp, err := GetEpsilonFrequencyItemsSketch(1024)
 	assert.NoError(t, err)
 	assert.Equal(t, esp, 3.5/1024)
 
-	_, err = GetEpsilonItemsSketch(1000)
+	_, err = GetEpsilonFrequencyItemsSketch(1000)
 	assert.Error(t, err)
 }
 
 func TestItemGetAprioriError(t *testing.T) {
 	eps := 3.5 / 1024
-	apr, err := GetAprioriErrorItemsSketch(1024, 10_000)
+	apr, err := GetAprioriErrorFrequencyItemsSketch(1024, 10_000)
 	assert.NoError(t, err)
 	assert.Equal(t, apr, eps*10_000)
 }
 
 func BenchmarkItemSketch(b *testing.B) {
-	sketch, err := NewItemsSketch[int64](128, 8, common.ArrayOfLongsSerDe{})
+	sketch, err := NewFrequencyItemsSketch[int64](128, 8, common.ArrayOfLongsSerDe{})
 	assert.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		sketch.Update(int64(i))

--- a/frequencies/items_sketch_test.go
+++ b/frequencies/items_sketch_test.go
@@ -19,128 +19,14 @@ package frequencies
 
 import (
 	"encoding/binary"
+	"github.com/apache/datasketches-go/common"
+	"github.com/stretchr/testify/assert"
 	"strconv"
 	"testing"
-	"unsafe"
-
-	"github.com/apache/datasketches-go/internal"
-	"github.com/stretchr/testify/assert"
-	"github.com/twmb/murmur3"
 )
 
-type StringItemsSketchOp struct {
-}
-
-func (h StringItemsSketchOp) Hash(item string) uint64 {
-	datum := unsafe.Slice(unsafe.StringData(item), len(item))
-	return murmur3.SeedSum64(internal.DEFAULT_UPDATE_SEED, datum[:])
-}
-
-func (h StringItemsSketchOp) SerializeOneToSlice(item string) []byte {
-	panic("not implemented")
-}
-
-func (h StringItemsSketchOp) SerializeManyToSlice(item []string) []byte {
-	if len(item) == 0 {
-		return []byte{}
-	}
-	totalBytes := 0
-	numItems := len(item)
-	serialized2DArray := make([][]byte, numItems)
-	for i := 0; i < numItems; i++ {
-		serialized2DArray[i] = []byte(item[i])
-		totalBytes += len(serialized2DArray[i]) + 4
-	}
-	bytesOut := make([]byte, totalBytes)
-	offset := 0
-	for i := 0; i < numItems; i++ {
-		utf8len := len(serialized2DArray[i])
-		binary.LittleEndian.PutUint32(bytesOut[offset:], uint32(utf8len))
-		offset += 4
-		copy(bytesOut[offset:], serialized2DArray[i])
-		offset += utf8len
-	}
-	return bytesOut
-}
-
-func (h StringItemsSketchOp) DeserializeManyFromSlice(slc []byte, offset int, length int) []string {
-	if length == 0 {
-		return []string{}
-	}
-	array := make([]string, length)
-	offsetBytes := offset
-	for i := 0; i < length; i++ {
-		strLength := int(binary.LittleEndian.Uint32(slc[offsetBytes:]))
-		offsetBytes += 4
-		utf8Bytes := make([]byte, strLength)
-		copy(utf8Bytes, slc[offsetBytes:])
-		offsetBytes += strLength
-		array[i] = string(utf8Bytes)
-	}
-	return array
-}
-
-type StringPointerSketchOp struct {
-}
-
-func (h StringPointerSketchOp) Hash(item *string) uint64 {
-	datum := unsafe.Slice(unsafe.StringData(*item), len(*item))
-	return murmur3.SeedSum64(internal.DEFAULT_UPDATE_SEED, datum[:])
-}
-
-func (h StringPointerSketchOp) SerializeOneToSlice(item *string) []byte {
-	panic("not implemented")
-}
-
-func (h StringPointerSketchOp) SerializeManyToSlice(item []*string) []byte {
-	panic("not implemented")
-}
-
-func (h StringPointerSketchOp) DeserializeManyFromSlice(slc []byte, offset int, length int) []*string {
-	panic("not implemented")
-}
-
-type IntItemsSketchOp struct {
-	scratch [8]byte
-}
-
-func (h IntItemsSketchOp) Hash(item int64) uint64 {
-	binary.LittleEndian.PutUint64(h.scratch[:], uint64(item))
-	return murmur3.SeedSum64(internal.DEFAULT_UPDATE_SEED, h.scratch[:])
-}
-
-func (h IntItemsSketchOp) SerializeOneToSlice(item int64) []byte {
-	panic("not implemented")
-}
-
-func (h IntItemsSketchOp) SerializeManyToSlice(item []int64) []byte {
-	if len(item) == 0 {
-		return []byte{}
-	}
-	bytes := make([]byte, 8*len(item))
-	offset := 0
-	for i := 0; i < len(item); i++ {
-		binary.LittleEndian.PutUint64(bytes[offset:], uint64(item[i]))
-		offset += 8
-	}
-	return bytes
-}
-
-func (h IntItemsSketchOp) DeserializeManyFromSlice(slc []byte, offset int, length int) []int64 {
-	if length == 0 {
-		return []int64{}
-	}
-	array := make([]int64, 0, length)
-	offsetBytes := offset
-	for i := 0; i < length; i++ {
-		array = append(array, int64(binary.LittleEndian.Uint64(slc[offsetBytes:])))
-		offsetBytes += 8
-	}
-	return array
-}
-
 func TestEmpty(t *testing.T) {
-	h := StringItemsSketchOp{}
+	h := common.ArrayOfStringsSerDe{}
 	sketch, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, h)
 	assert.NoError(t, err)
 	assert.True(t, sketch.IsEmpty())
@@ -154,26 +40,8 @@ func TestEmpty(t *testing.T) {
 	assert.Equal(t, ub, int64(0))
 }
 
-func TestNilInput(t *testing.T) {
-	h := StringPointerSketchOp{}
-	sketch, err := NewItemsSketchWithMaxMapSize[*string](1<<_LG_MIN_MAP_SIZE, h)
-	assert.NoError(t, err)
-	err = sketch.Update(nil)
-	assert.NoError(t, err)
-	assert.True(t, sketch.IsEmpty())
-	assert.Equal(t, sketch.GetNumActiveItems(), 0)
-	assert.Equal(t, sketch.GetStreamLength(), int64(0))
-	lb, err := sketch.GetLowerBound(nil)
-	assert.NoError(t, err)
-	assert.Equal(t, lb, int64(0))
-	ub, err := sketch.GetUpperBound(nil)
-	assert.NoError(t, err)
-	assert.Equal(t, ub, int64(0))
-
-}
-
 func TestOneItem(t *testing.T) {
-	sketch, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	err = sketch.Update("a")
 	assert.NoError(t, err)
@@ -189,7 +57,7 @@ func TestOneItem(t *testing.T) {
 }
 
 func TestSeveralItem(t *testing.T) {
-	sketch, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	err = sketch.Update("a")
 	assert.NoError(t, err)
@@ -238,7 +106,7 @@ func TestSeveralItem(t *testing.T) {
 }
 
 func TestEstimationMode(t *testing.T) {
-	sketch, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, IntItemsSketchOp{})
+	sketch, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	err = sketch.UpdateMany(1, 10)
 	assert.NoError(t, err)
@@ -298,10 +166,10 @@ func TestEstimationMode(t *testing.T) {
 }
 
 func TestSerializeStringDeserializeEmpty(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch1, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	bytes := sketch1.ToSlice()
-	sketch2, err := NewItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
+	sketch2, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	assert.True(t, sketch2.IsEmpty())
 	assert.Equal(t, sketch2.GetNumActiveItems(), 0)
@@ -309,7 +177,7 @@ func TestSerializeStringDeserializeEmpty(t *testing.T) {
 }
 
 func TestSerializeDeserializeUtf8Strings(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch1, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	err = sketch1.Update("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	assert.NoError(t, err)
@@ -321,7 +189,7 @@ func TestSerializeDeserializeUtf8Strings(t *testing.T) {
 	assert.NoError(t, err)
 
 	bytes := sketch1.ToSlice()
-	sketch2, err := NewItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
+	sketch2, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	err = sketch2.Update("bbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
 	assert.NoError(t, err)
@@ -348,14 +216,14 @@ func TestSerializeDeserializeUtf8Strings(t *testing.T) {
 }
 
 func TestSerializeDeserializeLong(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, IntItemsSketchOp{})
+	sketch1, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
 	sketch1.Update(1)
 	sketch1.Update(2)
 	sketch1.Update(3)
 	sketch1.Update(4)
 
 	bytes := sketch1.ToSlice()
-	sketch2, err := NewItemsSketchFromSlice[int64](bytes, IntItemsSketchOp{})
+	sketch2, err := NewItemsSketchFromSlice[int64](bytes, common.ArrayOfLongsSerDe{})
 	sketch2.Update(2)
 	sketch2.Update(3)
 	sketch2.Update(2)
@@ -378,7 +246,7 @@ func TestSerializeDeserializeLong(t *testing.T) {
 }
 
 func TestResize(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[string](2<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch1, err := NewItemsSketchWithMaxMapSize[string](2<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
 	for i := 0; i < 32; i++ {
 		err = sketch1.UpdateMany(strconv.Itoa(i), int64(i*i))
 		assert.NoError(t, err)
@@ -386,7 +254,7 @@ func TestResize(t *testing.T) {
 }
 
 func TestMergeExact(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch1, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	err = sketch1.Update("a")
 	assert.NoError(t, err)
@@ -397,7 +265,7 @@ func TestMergeExact(t *testing.T) {
 	err = sketch1.Update("d")
 	assert.NoError(t, err)
 
-	sketch2, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch2, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	err = sketch2.Update("b")
 	assert.NoError(t, err)
@@ -426,20 +294,20 @@ func TestMergeExact(t *testing.T) {
 }
 
 func TestNullMapReturns(t *testing.T) {
-	map1, err := newReversePurgeItemHashMap[int64](1<<_LG_MIN_MAP_SIZE, IntItemsSketchOp{})
+	map1, err := newReversePurgeItemHashMap[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	assert.Nil(t, map1.getActiveKeys())
 	assert.Nil(t, map1.getActiveValues())
 }
 
 func TestMisc(t *testing.T) {
-	sk1, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, IntItemsSketchOp{})
+	sk1, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	assert.Equal(t, sk1.GetCurrentMapCapacity(), 6)
 	est, err := sk1.GetEstimate(1)
 	assert.NoError(t, err)
 	assert.Equal(t, est, int64(0))
-	sk2, err := NewItemsSketchWithMaxMapSize[int64](8, IntItemsSketchOp{})
+	sk2, err := NewItemsSketchWithMaxMapSize[int64](8, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	_, err = sk1.Merge(sk2)
 	assert.NoError(t, err)
@@ -460,14 +328,14 @@ func TestMisc(t *testing.T) {
 }
 
 func TestToString(t *testing.T) {
-	sk, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, IntItemsSketchOp{})
+	sk, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	err = sk.Update(1)
 	t.Log(sk.ToString())
 }
 
 func TestFrequentItems1(t *testing.T) {
-	fis, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, IntItemsSketchOp{})
+	fis, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	fis.Update(1)
 	rows, err := fis.GetFrequentItems(ErrorTypeEnum.NoFalsePositives)
@@ -484,14 +352,14 @@ func TestFrequentItems1(t *testing.T) {
 }
 
 func TestUpdateExceptions(t *testing.T) {
-	sk1, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, IntItemsSketchOp{})
+	sk1, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	err = sk1.UpdateMany(1, -1)
 	assert.Error(t, err)
 }
 
 func TestMemExceptions(t *testing.T) {
-	sk1, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, IntItemsSketchOp{})
+	sk1, err := NewItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	sk1.Update(1)
 	bytes := sk1.ToSlice()
@@ -511,7 +379,7 @@ func TestMemExceptions(t *testing.T) {
 }
 
 func TestOneItemUtf8(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, StringItemsSketchOp{})
+	sketch1, err := NewItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	err = sketch1.Update("\u5fb5")
 	assert.NoError(t, err)
@@ -523,7 +391,7 @@ func TestOneItemUtf8(t *testing.T) {
 	assert.Equal(t, est, int64(1))
 
 	bytes := sketch1.ToSlice()
-	sketch2, err := NewItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
+	sketch2, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 	assert.NoError(t, err)
 	assert.False(t, sketch2.IsEmpty())
 	assert.Equal(t, sketch2.GetNumActiveItems(), 1)
@@ -550,7 +418,7 @@ func TestItemGetAprioriError(t *testing.T) {
 }
 
 func BenchmarkItemSketch(b *testing.B) {
-	sketch, err := NewItemsSketch[int64](128, 8, IntItemsSketchOp{})
+	sketch, err := NewItemsSketch[int64](128, 8, common.ArrayOfLongsSerDe{})
 	assert.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		sketch.Update(int64(i))

--- a/frequencies/reverse_purge_item_hash_map.go
+++ b/frequencies/reverse_purge_item_hash_map.go
@@ -19,6 +19,7 @@ package frequencies
 
 import (
 	"fmt"
+	"github.com/apache/datasketches-go/common"
 	"github.com/apache/datasketches-go/internal"
 	"math/bits"
 	"strings"
@@ -31,7 +32,7 @@ type reversePurgeItemHashMap[C comparable] struct {
 	values        []int64
 	states        []int16
 	numActive     int
-	operations    ItemSketchOp[C]
+	operations    common.ItemSketchOp[C]
 }
 
 type iteratorItemHashMap[C comparable] struct {
@@ -57,7 +58,7 @@ const (
 //   - mapSize, This determines the number of cells in the arrays underlying the
 //     HashMap implementation and must be a power of 2.
 //     The hashFn table will be expected to store reversePurgeItemHashMapLoadFactor * mapSize (key, value) pairs.
-func newReversePurgeItemHashMap[C comparable](mapSize int, operations ItemSketchOp[C]) (*reversePurgeItemHashMap[C], error) {
+func newReversePurgeItemHashMap[C comparable](mapSize int, operations common.ItemSketchOp[C]) (*reversePurgeItemHashMap[C], error) {
 	lgLength, err := internal.ExactLog2(mapSize)
 	if err != nil {
 		return nil, err

--- a/frequencies/serde_compat_test.go
+++ b/frequencies/serde_compat_test.go
@@ -24,7 +24,7 @@ import (
 )
 
 func TestItemsToLongs(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[int64](8, common.ArrayOfLongsSerDe{})
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[int64](8, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	sketch1.Update(1)
 	sketch1.Update(2)
@@ -64,7 +64,7 @@ func TestLongToItems(t *testing.T) {
 	sketch1.Update(4)
 
 	bytes := sketch1.ToSlice()
-	sketch2, err := NewItemsSketchFromSlice[int64](bytes, common.ArrayOfLongsSerDe{})
+	sketch2, err := NewFrequencyItemsSketchFromSlice[int64](bytes, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	sketch2.Update(2)
 	sketch2.Update(3)

--- a/frequencies/serde_compat_test.go
+++ b/frequencies/serde_compat_test.go
@@ -18,12 +18,13 @@
 package frequencies
 
 import (
+	"github.com/apache/datasketches-go/common"
 	"github.com/stretchr/testify/assert"
 	"testing"
 )
 
 func TestItemsToLongs(t *testing.T) {
-	sketch1, err := NewItemsSketchWithMaxMapSize[int64](8, IntItemsSketchOp{})
+	sketch1, err := NewItemsSketchWithMaxMapSize[int64](8, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	sketch1.Update(1)
 	sketch1.Update(2)
@@ -63,7 +64,7 @@ func TestLongToItems(t *testing.T) {
 	sketch1.Update(4)
 
 	bytes := sketch1.ToSlice()
-	sketch2, err := NewItemsSketchFromSlice[int64](bytes, IntItemsSketchOp{})
+	sketch2, err := NewItemsSketchFromSlice[int64](bytes, common.ArrayOfLongsSerDe{})
 	assert.NoError(t, err)
 	sketch2.Update(2)
 	sketch2.Update(3)

--- a/frequencies/sketch_serialization_test.go
+++ b/frequencies/sketch_serialization_test.go
@@ -66,7 +66,7 @@ func TestGenerateGoBinariesForCompatibilityTestingLongsSketch(t *testing.T) {
 	t.Run("String Frequency", func(t *testing.T) {
 		nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range nArr {
-			sk, err := NewItemsSketchWithMaxMapSize[string](64, common.ArrayOfStringsSerDe{})
+			sk, err := NewFrequencyItemsSketchWithMaxMapSize[string](64, common.ArrayOfStringsSerDe{})
 			assert.NoError(t, err)
 			for i := 1; i <= n; i++ {
 				err = sk.Update(strconv.Itoa(i))
@@ -94,7 +94,7 @@ func TestGenerateGoBinariesForCompatibilityTestingLongsSketch(t *testing.T) {
 	})
 
 	t.Run("String ut8", func(t *testing.T) {
-		sk, err := NewItemsSketchWithMaxMapSize[string](64, common.ArrayOfStringsSerDe{})
+		sk, err := NewFrequencyItemsSketchWithMaxMapSize[string](64, common.ArrayOfStringsSerDe{})
 		assert.NoError(t, err)
 
 		assert.NoError(t, sk.UpdateMany("абвгд", 1))
@@ -116,7 +116,7 @@ func TestGenerateGoBinariesForCompatibilityTestingLongsSketch(t *testing.T) {
 	})
 
 	t.Run("String ascii", func(t *testing.T) {
-		sk, err := NewItemsSketchWithMaxMapSize[string](64, common.ArrayOfStringsSerDe{})
+		sk, err := NewFrequencyItemsSketchWithMaxMapSize[string](64, common.ArrayOfStringsSerDe{})
 		assert.NoError(t, err)
 
 		assert.NoError(t, sk.UpdateMany("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1))
@@ -166,7 +166,7 @@ func TestJavaCompat(t *testing.T) {
 		for _, n := range nArr {
 			bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_n%d_java.sk", internal.JavaPath, n))
 			assert.NoError(t, err)
-			sketch, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+			sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 			if err != nil {
 				return
 			}
@@ -188,7 +188,7 @@ func TestJavaCompat(t *testing.T) {
 	t.Run("String utf8", func(t *testing.T) {
 		bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_utf8_java.sk", internal.JavaPath))
 		assert.NoError(t, err)
-		sketch, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+		sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 		if err != nil {
 			return
 		}
@@ -221,7 +221,7 @@ func TestJavaCompat(t *testing.T) {
 	t.Run("String ascii", func(t *testing.T) {
 		bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_ascii_java.sk", internal.JavaPath))
 		assert.NoError(t, err)
-		sketch, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+		sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 		if err != nil {
 			return
 		}
@@ -273,7 +273,7 @@ func TestCppCompat(t *testing.T) {
 		for _, n := range nArr {
 			bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_n%d_cpp.sk", internal.CppPath, n))
 			assert.NoError(t, err)
-			sketch, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+			sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 			if err != nil {
 				return
 			}
@@ -295,7 +295,7 @@ func TestCppCompat(t *testing.T) {
 	t.Run("String utf8", func(t *testing.T) {
 		bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_utf8_cpp.sk", internal.CppPath))
 		assert.NoError(t, err)
-		sketch, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+		sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 		if err != nil {
 			return
 		}
@@ -328,7 +328,7 @@ func TestCppCompat(t *testing.T) {
 	t.Run("String ascii", func(t *testing.T) {
 		bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_ascii_cpp.sk", internal.CppPath))
 		assert.NoError(t, err)
-		sketch, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+		sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 		if err != nil {
 			return
 		}

--- a/frequencies/sketch_serialization_test.go
+++ b/frequencies/sketch_serialization_test.go
@@ -19,6 +19,7 @@ package frequencies
 
 import (
 	"fmt"
+	"github.com/apache/datasketches-go/common"
 	"os"
 	"strconv"
 	"testing"
@@ -65,7 +66,7 @@ func TestGenerateGoBinariesForCompatibilityTestingLongsSketch(t *testing.T) {
 	t.Run("String Frequency", func(t *testing.T) {
 		nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range nArr {
-			sk, err := NewItemsSketchWithMaxMapSize[string](64, StringItemsSketchOp{})
+			sk, err := NewItemsSketchWithMaxMapSize[string](64, common.ArrayOfStringsSerDe{})
 			assert.NoError(t, err)
 			for i := 1; i <= n; i++ {
 				err = sk.Update(strconv.Itoa(i))
@@ -93,7 +94,7 @@ func TestGenerateGoBinariesForCompatibilityTestingLongsSketch(t *testing.T) {
 	})
 
 	t.Run("String ut8", func(t *testing.T) {
-		sk, err := NewItemsSketchWithMaxMapSize[string](64, StringItemsSketchOp{})
+		sk, err := NewItemsSketchWithMaxMapSize[string](64, common.ArrayOfStringsSerDe{})
 		assert.NoError(t, err)
 
 		assert.NoError(t, sk.UpdateMany("абвгд", 1))
@@ -115,7 +116,7 @@ func TestGenerateGoBinariesForCompatibilityTestingLongsSketch(t *testing.T) {
 	})
 
 	t.Run("String ascii", func(t *testing.T) {
-		sk, err := NewItemsSketchWithMaxMapSize[string](64, StringItemsSketchOp{})
+		sk, err := NewItemsSketchWithMaxMapSize[string](64, common.ArrayOfStringsSerDe{})
 		assert.NoError(t, err)
 
 		assert.NoError(t, sk.UpdateMany("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1))
@@ -165,7 +166,7 @@ func TestJavaCompat(t *testing.T) {
 		for _, n := range nArr {
 			bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_n%d_java.sk", internal.JavaPath, n))
 			assert.NoError(t, err)
-			sketch, err := NewItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
+			sketch, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 			if err != nil {
 				return
 			}
@@ -187,7 +188,7 @@ func TestJavaCompat(t *testing.T) {
 	t.Run("String utf8", func(t *testing.T) {
 		bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_utf8_java.sk", internal.JavaPath))
 		assert.NoError(t, err)
-		sketch, err := NewItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
+		sketch, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 		if err != nil {
 			return
 		}
@@ -220,7 +221,7 @@ func TestJavaCompat(t *testing.T) {
 	t.Run("String ascii", func(t *testing.T) {
 		bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_ascii_java.sk", internal.JavaPath))
 		assert.NoError(t, err)
-		sketch, err := NewItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
+		sketch, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 		if err != nil {
 			return
 		}
@@ -272,7 +273,7 @@ func TestCppCompat(t *testing.T) {
 		for _, n := range nArr {
 			bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_n%d_cpp.sk", internal.CppPath, n))
 			assert.NoError(t, err)
-			sketch, err := NewItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
+			sketch, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 			if err != nil {
 				return
 			}
@@ -294,7 +295,7 @@ func TestCppCompat(t *testing.T) {
 	t.Run("String utf8", func(t *testing.T) {
 		bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_utf8_cpp.sk", internal.CppPath))
 		assert.NoError(t, err)
-		sketch, err := NewItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
+		sketch, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 		if err != nil {
 			return
 		}
@@ -327,7 +328,7 @@ func TestCppCompat(t *testing.T) {
 	t.Run("String ascii", func(t *testing.T) {
 		bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_ascii_cpp.sk", internal.CppPath))
 		assert.NoError(t, err)
-		sketch, err := NewItemsSketchFromSlice[string](bytes, StringItemsSketchOp{})
+		sketch, err := NewItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
 		if err != nil {
 			return
 		}

--- a/hll/coupon_list_test.go
+++ b/hll/coupon_list_test.go
@@ -26,7 +26,7 @@ import (
 func TestCouponIterator(t *testing.T) {
 	lgK := 4
 	n := 7
-	sk, err := NewHllSketchWithLgK(lgK)
+	sk, err := NewHllSketch(lgK, TgtHllTypeDefault)
 	assert.NoError(t, err)
 	for i := 0; i < n; i++ {
 		assert.NoError(t, sk.UpdateInt64(int64(i)))
@@ -41,7 +41,7 @@ func TestCouponIterator(t *testing.T) {
 }
 
 func TestCouponDuplicatesAndMisc(t *testing.T) {
-	sk, err := NewHllSketchWithLgK(8)
+	sk, err := NewHllSketch(8, TgtHllTypeDefault)
 	assert.NoError(t, err)
 	for i := 1; i <= 7; i++ {
 		assert.NoError(t, sk.UpdateInt64(int64(i)))
@@ -84,7 +84,7 @@ func TestToCouponSliceDeserialize(t *testing.T) {
 }
 
 func toCouponSliceDeserialize(t *testing.T, lgK int) {
-	sk1, err := NewHllSketchWithLgK(lgK)
+	sk1, err := NewHllSketch(lgK, TgtHllTypeDefault)
 	assert.NoError(t, err)
 
 	u := 7

--- a/hll/hll_sketch.go
+++ b/hll/hll_sketch.go
@@ -170,19 +170,9 @@ func NewHllSketch(lgConfigK int, tgtHllType TgtHllType) (HllSketch, error) {
 	return newHllSketchState(&couponList), nil
 }
 
-// NewHllSketchWithLgK constructs a new on-heap sketch with the default tgtHllType.
-//
-//   - lgConfigK, the Log2 of K for the target HLL sketch. This value must be between 4 and 21 inclusively.
-func NewHllSketchWithLgK(lgConfigK int) (HllSketch, error) {
-	lgK, err := checkLgK(lgConfigK)
-	if err != nil {
-		return nil, err
-	}
-	couponList, err := newCouponList(lgK, TgtHllTypeDefault, curModeList)
-	if err != nil {
-		return nil, err
-	}
-	return newHllSketchState(&couponList), nil
+// NewHllSketchWithDefault constructs a new on-heap sketch with the default lgK and tgtHllType.
+func NewHllSketchWithDefault() (HllSketch, error) {
+	return NewHllSketch(defaultLgK, TgtHllTypeDefault)
 }
 
 // NewHllSketchFromSlice deserialize a given byte slice, which must be a valid HllSketch image and may have data.

--- a/hll/union_test.go
+++ b/hll/union_test.go
@@ -251,7 +251,7 @@ func TestUnionWithWrap(t *testing.T) {
 func TestUnionWithWrap2(t *testing.T) {
 	lgK := 10
 	n := 128
-	sk, err := NewHllSketchWithLgK(lgK)
+	sk, err := NewHllSketch(lgK, TgtHllTypeDefault)
 	assert.NoError(t, err)
 	for i := 0; i < n; i++ {
 		assert.NoError(t, sk.UpdateInt64(int64(i)))
@@ -310,9 +310,9 @@ func TestCheckUnionDeserializeRebuildAfterMerge(t *testing.T) {
 	lgK := 12
 	//Build 2 sketches in HLL (dense) mode.
 	u := 1 << (lgK - 3) //(lgK < 8) ? 16 : 1 << (lgK - 3) //allows changing lgK above
-	sk1, err := NewHllSketchWithLgK(lgK)
+	sk1, err := NewHllSketch(lgK, TgtHllTypeDefault)
 	assert.NoError(t, err)
-	sk2, err := NewHllSketchWithLgK(lgK)
+	sk2, err := NewHllSketch(lgK, TgtHllTypeDefault)
 	assert.NoError(t, err)
 	for i := 0; i < u; i++ {
 		assert.NoError(t, sk1.UpdateInt64(int64(i)))

--- a/kll/items_sketch.go
+++ b/kll/items_sketch.go
@@ -195,14 +195,14 @@ func (s *ItemsSketch[C]) GetMaxItem() (C, error) {
 	return *s.maxItem, nil
 }
 
+// IsEstimationMode returns true if the sketch is in estimation mode, otherwise false.
 func (s *ItemsSketch[C]) IsEstimationMode() bool {
 	return s.numLevels > 1
 }
 
-func (s *ItemsSketch[C]) IsLevelZeroSorted() bool {
-	return s.isLevelZeroSorted
-}
-
+// GetTotalItemsArray return the serialized byte array of the entire internal items hypothetical structure.
+// It does not include the preamble, the levels array, or minimum or maximum items.
+// It may include empty or garbage items.
 func (s *ItemsSketch[C]) GetTotalItemsArray() []C {
 	if s.n == 0 {
 		return make([]C, s.k)
@@ -212,6 +212,8 @@ func (s *ItemsSketch[C]) GetTotalItemsArray() []C {
 	return outArr
 }
 
+// GetRank return the normalized rank corresponding to the given a quantile.
+// if INCLUSIVE the given quantile is included into the rank.
 func (s *ItemsSketch[C]) GetRank(item C, inclusive bool) (float64, error) {
 	if s.IsEmpty() {
 		return 0, fmt.Errorf("operation is undefined for an empty sketch")
@@ -223,6 +225,8 @@ func (s *ItemsSketch[C]) GetRank(item C, inclusive bool) (float64, error) {
 	return s.sortedView.GetRank(item, inclusive)
 }
 
+// GetRanks return an array of normalized ranks corresponding to the given array of quantiles and the given search criterion.
+// if INCLUSIVE, the given quantiles include the rank directly corresponding to each quantile.
 func (s *ItemsSketch[C]) GetRanks(item []C, inclusive bool) ([]float64, error) {
 	if s.IsEmpty() {
 		return nil, fmt.Errorf("operation is undefined for an empty sketch")
@@ -241,6 +245,9 @@ func (s *ItemsSketch[C]) GetRanks(item []C, inclusive bool) ([]float64, error) {
 	return ranks, nil
 }
 
+// GetQuantile return the approximate quantile of the given normalized rank and the given search criterion.
+// If INCLUSIVE, the given rank includes all quantiles <= the quantile directly corresponding to the given rank.
+// If EXCLUSIVE, the given rank includes all quantiles < the quantile directly corresponding to the given rank.
 func (s *ItemsSketch[C]) GetQuantile(rank float64, inclusive bool) (C, error) {
 	if s.IsEmpty() {
 		return s.itemsSketchOp.Identity(), fmt.Errorf("operation is undefined for an empty sketch")
@@ -255,6 +262,8 @@ func (s *ItemsSketch[C]) GetQuantile(rank float64, inclusive bool) (C, error) {
 	return s.sortedView.GetQuantile(rank, inclusive)
 }
 
+// GetQuantiles return an array of quantiles from the given array of normalized ranks.
+// if INCLUSIVE, the given ranks include all quantiles <= the quantile directly corresponding to each rank.
 func (s *ItemsSketch[C]) GetQuantiles(ranks []float64, inclusive bool) ([]C, error) {
 	if s.IsEmpty() {
 		return nil, fmt.Errorf("operation is undefined for an empty sketch")
@@ -360,7 +369,7 @@ func (s *ItemsSketch[C]) ToSlice() ([]byte, error) {
 	if s.IsEmpty() {
 		flags |= _EMPTY_BIT_MASK
 	}
-	if s.IsLevelZeroSorted() {
+	if s.isLevelZeroSorted {
 		flags |= _LEVEL_ZERO_SORTED_BIT_MASK
 	}
 	if s.n == 1 {

--- a/kll/items_sketch_iterator.go
+++ b/kll/items_sketch_iterator.go
@@ -30,7 +30,7 @@ type ItemsSketchIterator[C comparable] struct {
 	itemsSketchOp common.ItemSketchOp[C]
 }
 
-func NewItemsSketchIterator[C comparable](
+func newItemsSketchIterator[C comparable](
 	quantiles []C,
 	levelsArr []uint32,
 	numLevels int,
@@ -70,6 +70,10 @@ func (s *ItemsSketchIterator[C]) Next() bool {
 	return true
 }
 
+// GetQuantile return the generic quantile at the current index.
+//
+// Don't call this before calling next() for the first time
+// or after getting false from next().
 func (s *ItemsSketchIterator[C]) GetQuantile() C {
 	return s.quantiles[s.index]
 }

--- a/kll/items_sketch_iterator.go
+++ b/kll/items_sketch_iterator.go
@@ -17,6 +17,8 @@
 
 package kll
 
+import "github.com/apache/datasketches-go/common"
+
 type ItemsSketchIterator[C comparable] struct {
 	quantiles     []C
 	levelsArr     []uint32
@@ -25,7 +27,7 @@ type ItemsSketchIterator[C comparable] struct {
 	level         int
 	weight        int64
 	isInitialized bool
-	itemsSketchOp ItemSketchOp[C]
+	itemsSketchOp common.ItemSketchOp[C]
 }
 
 func NewItemsSketchIterator[C comparable](

--- a/kll/items_sketch_sorted_view.go
+++ b/kll/items_sketch_sorted_view.go
@@ -19,6 +19,7 @@ package kll
 
 import (
 	"errors"
+	"github.com/apache/datasketches-go/common"
 	"github.com/apache/datasketches-go/internal"
 	"sort"
 )
@@ -29,7 +30,7 @@ type ItemsSketchSortedView[C comparable] struct {
 	totalN        uint64
 	maxItem       C
 	minItem       C
-	itemsSketchOp ItemSketchOp[C]
+	itemsSketchOp common.ItemSketchOp[C]
 }
 
 func newItemsSketchSortedView[C comparable](sketch *ItemsSketch[C]) (*ItemsSketchSortedView[C], error) {
@@ -54,7 +55,7 @@ func newItemsSketchSortedView[C comparable](sketch *ItemsSketch[C]) (*ItemsSketc
 	}
 	if !sketch.IsLevelZeroSorted() {
 		subSlice := srcQuantiles[srcLevels[0]:srcLevels[1]]
-		lessFn := sketch.itemsSketchOp.lessFn()
+		lessFn := sketch.itemsSketchOp.LessFn()
 		sort.Slice(subSlice, func(a, b int) bool {
 			return lessFn(subSlice[a], subSlice[b])
 		})
@@ -81,7 +82,7 @@ func (s *ItemsSketchSortedView[C]) GetRank(item C, inclusive bool) (float64, err
 	if inclusive {
 		crit = internal.InequalityLE
 	}
-	index := internal.FindWithInequality(s.quantiles, 0, length-1, item, crit, s.itemsSketchOp.lessFn())
+	index := internal.FindWithInequality(s.quantiles, 0, length-1, item, crit, s.itemsSketchOp.LessFn())
 	if index == -1 {
 		return 0, nil //EXCLUSIVE (LT) case: quantile <= minQuantile; INCLUSIVE (LE) case: quantile < minQuantile
 	}
@@ -90,11 +91,11 @@ func (s *ItemsSketchSortedView[C]) GetRank(item C, inclusive bool) (float64, err
 
 func (s *ItemsSketchSortedView[C]) GetQuantile(rank float64, inclusive bool) (C, error) {
 	if s.totalN == 0 {
-		return s.itemsSketchOp.identity(), errors.New("empty sketch")
+		return s.itemsSketchOp.Identity(), errors.New("empty sketch")
 	}
 	err := checkNormalizedRankBounds(rank)
 	if err != nil {
-		return s.itemsSketchOp.identity(), err
+		return s.itemsSketchOp.Identity(), err
 	}
 	index := s.getQuantileIndex(rank, inclusive)
 	return s.quantiles[index], nil
@@ -104,7 +105,7 @@ func (s *ItemsSketchSortedView[C]) GetPMF(splitPoints []C, inclusive bool) ([]fl
 	if s.totalN == 0 {
 		return nil, errors.New("empty sketch")
 	}
-	err := checkItems(splitPoints, s.itemsSketchOp.lessFn())
+	err := checkItems(splitPoints, s.itemsSketchOp.LessFn())
 	if err != nil {
 		return nil, err
 	}
@@ -123,7 +124,7 @@ func (s *ItemsSketchSortedView[C]) GetCDF(splitPoints []C, inclusive bool) ([]fl
 	if s.totalN == 0 {
 		return nil, errors.New("empty sketch")
 	}
-	err := checkItems(splitPoints, s.itemsSketchOp.lessFn())
+	err := checkItems(splitPoints, s.itemsSketchOp.LessFn())
 	if err != nil {
 		return nil, err
 	}
@@ -181,7 +182,7 @@ func (s *ItemsSketchSortedView[C]) GetPartitionBoundaries(numEquallySized int, i
 	return newItemsSketchPartitionBoundaries[C](s.totalN, evSpQuantiles, evSpNatRanks, evSpNormRanks, s.maxItem, s.minItem, inclusive)
 }
 
-func populateFromSketch[C comparable](srcQuantiles []C, levels []uint32, numLevels uint8, numQuantiles uint32, itemsSketchOp ItemSketchOp[C]) ([]C, []int64) {
+func populateFromSketch[C comparable](srcQuantiles []C, levels []uint32, numLevels uint8, numQuantiles uint32, itemsSketchOp common.ItemSketchOp[C]) ([]C, []int64) {
 	quantiles := make([]C, numQuantiles)
 	cumWeights := make([]int64, numQuantiles)
 	myLevels := make([]uint32, numLevels+1)
@@ -212,7 +213,7 @@ func populateFromSketch[C comparable](srcQuantiles []C, levels []uint32, numLeve
 	return quantiles, cumWeights
 }
 
-func blockyTandemMergeSort[C comparable](quantiles []C, weights []int64, levels []uint32, numLevels uint8, itemsSketchOp ItemSketchOp[C]) {
+func blockyTandemMergeSort[C comparable](quantiles []C, weights []int64, levels []uint32, numLevels uint8, itemsSketchOp common.ItemSketchOp[C]) {
 	if numLevels == 1 {
 		return
 	}
@@ -226,7 +227,7 @@ func blockyTandemMergeSort[C comparable](quantiles []C, weights []int64, levels 
 	blockyTandemMergeSortRecursion(quantilesTmp, weightsTmp, quantiles, weights, levels, 0, numLevels, itemsSketchOp)
 }
 
-func blockyTandemMergeSortRecursion[C comparable](quantilesSrc []C, weightsSrc []int64, quantilesDst []C, weightsDst []int64, levels []uint32, startingLevel uint8, numLevels uint8, itemsSketchOp ItemSketchOp[C]) {
+func blockyTandemMergeSortRecursion[C comparable](quantilesSrc []C, weightsSrc []int64, quantilesDst []C, weightsDst []int64, levels []uint32, startingLevel uint8, numLevels uint8, itemsSketchOp common.ItemSketchOp[C]) {
 	if numLevels == 1 {
 		return
 	}
@@ -240,7 +241,7 @@ func blockyTandemMergeSortRecursion[C comparable](quantilesSrc []C, weightsSrc [
 	tandemMerge(quantilesSrc, weightsSrc, quantilesDst, weightsDst, levels, startingLevel1, numLevels1, startingLevel2, numLevels2, itemsSketchOp)
 }
 
-func tandemMerge[C comparable](quantilesSrc []C, weightsSrc []int64, quantilesDst []C, weightsDst []int64, levels []uint32, startingLevel1 uint8, numLevels1 uint8, startingLevel2 uint8, numLevels2 uint8, itemsSketchOp ItemSketchOp[C]) {
+func tandemMerge[C comparable](quantilesSrc []C, weightsSrc []int64, quantilesDst []C, weightsDst []int64, levels []uint32, startingLevel1 uint8, numLevels1 uint8, startingLevel2 uint8, numLevels2 uint8, itemsSketchOp common.ItemSketchOp[C]) {
 	fromIndex1 := levels[startingLevel1]
 	toIndex1 := levels[startingLevel1+numLevels1] // exclusive
 	fromIndex2 := levels[startingLevel2]
@@ -249,7 +250,7 @@ func tandemMerge[C comparable](quantilesSrc []C, weightsSrc []int64, quantilesDs
 	iSrc2 := fromIndex2
 	iDst := fromIndex1
 
-	lessFn := itemsSketchOp.lessFn()
+	lessFn := itemsSketchOp.LessFn()
 	for iSrc1 < toIndex1 && iSrc2 < toIndex2 {
 		if lessFn(quantilesSrc[iSrc1], quantilesSrc[iSrc2]) || quantilesSrc[iSrc1] == quantilesSrc[iSrc2] {
 			quantilesDst[iDst] = quantilesSrc[iSrc1]

--- a/kll/items_sketch_sorted_view.go
+++ b/kll/items_sketch_sorted_view.go
@@ -53,7 +53,7 @@ func newItemsSketchSortedView[C comparable](sketch *ItemsSketch[C]) (*ItemsSketc
 	if totalN == 0 {
 		return nil, errors.New("empty sketch")
 	}
-	if !sketch.IsLevelZeroSorted() {
+	if !sketch.isLevelZeroSorted {
 		subSlice := srcQuantiles[srcLevels[0]:srcLevels[1]]
 		lessFn := sketch.itemsSketchOp.LessFn()
 		sort.Slice(subSlice, func(a, b int) bool {

--- a/kll/items_sketch_sorted_view_iterator.go
+++ b/kll/items_sketch_sorted_view_iterator.go
@@ -42,6 +42,10 @@ func (i *ItemsSketchSortedViewIterator[C]) Next() bool {
 	return i.index < len(i.cumWeights)
 }
 
+// GetQuantile returns the quantile at the current index
+//
+// Don't call this before calling next() for the first time
+// or after getting false from next().
 func (i *ItemsSketchSortedViewIterator[C]) GetQuantile() C {
 	return i.quantiles[i.index]
 }

--- a/kll/utils.go
+++ b/kll/utils.go
@@ -141,10 +141,6 @@ func getNormalizedRankError(k uint16, pmf bool) float64 {
 	return _CDF_COEF / math.Pow(float64(k), _CDF_EXP)
 }
 
-func checkBounds(offset int, reqLen int, memCap int) bool {
-	return !((offset | reqLen | (offset + reqLen) | (memCap - (offset + reqLen))) < 0)
-}
-
 func evenlySpacedDoubles(value1 float64, value2 float64, num int) ([]float64, error) {
 	if num < 2 {
 		return nil, errors.New("num must be >= 2")


### PR DESCRIPTION

* Refactors the common SerDe used in the various sketches into a single shared package
* Add an example package with basic usage
* Renamed/aligned various public methods and added GoDoc to KLL public APis