### PR TITLE
Split Serde/Comparator/Hasher and add reverse KLL order test

### DIFF
--- a/common/item_sketch_double.go
+++ b/common/item_sketch_double.go
@@ -23,40 +23,43 @@ import (
 	"math"
 )
 
-type ArrayOfDoublesSerDe struct {
+type ItemSketchDoubleComparator struct {
+	ReverseOrder bool
+}
+type ItemSketchDoubleHasher struct {
 	scratch [8]byte
 }
+type ItemSketchDoubleSerDe struct{}
 
-func (f ArrayOfDoublesSerDe) Identity() float64 {
-	return 0
-}
-
-func (f ArrayOfDoublesSerDe) Hash(item float64) uint64 {
-	binary.LittleEndian.PutUint64(f.scratch[:], math.Float64bits(item))
-	return murmur3.SeedSum64(_DEFAULT_SERDE_HASH_SEED, f.scratch[:])
-}
-
-func (f ArrayOfDoublesSerDe) LessFn() LessFn[float64] {
+func (f ItemSketchDoubleComparator) CompareFn() CompareFn[float64] {
 	return func(a float64, b float64) bool {
+		if f.ReverseOrder {
+			return a > b
+		}
 		return a < b
 	}
 }
 
-func (f ArrayOfDoublesSerDe) SizeOf(item float64) int {
+func (f ItemSketchDoubleHasher) Hash(item float64) uint64 {
+	binary.LittleEndian.PutUint64(f.scratch[:], math.Float64bits(item))
+	return murmur3.SeedSum64(_DEFAULT_SERDE_HASH_SEED, f.scratch[:])
+}
+
+func (f ItemSketchDoubleSerDe) SizeOf(item float64) int {
 	return 8
 }
 
-func (f ArrayOfDoublesSerDe) SizeOfMany(mem []byte, offsetBytes int, numItems int) (int, error) {
+func (f ItemSketchDoubleSerDe) SizeOfMany(mem []byte, offsetBytes int, numItems int) (int, error) {
 	return numItems * 8, nil
 }
 
-func (f ArrayOfDoublesSerDe) SerializeOneToSlice(item float64) []byte {
+func (f ItemSketchDoubleSerDe) SerializeOneToSlice(item float64) []byte {
 	bytes := make([]byte, 8)
 	binary.LittleEndian.PutUint64(bytes, math.Float64bits(item))
 	return bytes
 }
 
-func (f ArrayOfDoublesSerDe) SerializeManyToSlice(item []float64) []byte {
+func (f ItemSketchDoubleSerDe) SerializeManyToSlice(item []float64) []byte {
 	if len(item) == 0 {
 		return []byte{}
 	}
@@ -69,7 +72,7 @@ func (f ArrayOfDoublesSerDe) SerializeManyToSlice(item []float64) []byte {
 	return bytes
 }
 
-func (f ArrayOfDoublesSerDe) DeserializeManyFromSlice(mem []byte, offsetBytes int, numItems int) ([]float64, error) {
+func (f ItemSketchDoubleSerDe) DeserializeManyFromSlice(mem []byte, offsetBytes int, numItems int) ([]float64, error) {
 	if numItems == 0 {
 		return []float64{}, nil
 	}

--- a/common/item_sketch_double.go
+++ b/common/item_sketch_double.go
@@ -23,17 +23,14 @@ import (
 	"math"
 )
 
-type ItemSketchDoubleComparator struct {
-	ReverseOrder bool
-}
 type ItemSketchDoubleHasher struct {
 	scratch [8]byte
 }
 type ItemSketchDoubleSerDe struct{}
 
-func (f ItemSketchDoubleComparator) CompareFn() CompareFn[float64] {
+var ItemSketchDoubleComparator = func(reverseOrder bool) CompareFn[float64] {
 	return func(a float64, b float64) bool {
-		if f.ReverseOrder {
+		if reverseOrder {
 			return a > b
 		}
 		return a < b

--- a/common/item_sketch_long.go
+++ b/common/item_sketch_long.go
@@ -22,40 +22,43 @@ import (
 	"github.com/twmb/murmur3"
 )
 
-type ArrayOfLongsSerDe struct {
+type ItemSketchLongComparator struct {
+	ReverseOrder bool
+}
+type ItemSketchLongHasher struct {
 	scratch [8]byte
 }
+type ItemSketchLongSerDe struct{}
 
-func (f ArrayOfLongsSerDe) Identity() int64 {
-	return 0
-}
-
-func (f ArrayOfLongsSerDe) Hash(item int64) uint64 {
-	binary.LittleEndian.PutUint64(f.scratch[:], uint64(item))
-	return murmur3.SeedSum64(_DEFAULT_SERDE_HASH_SEED, f.scratch[:])
-}
-
-func (f ArrayOfLongsSerDe) LessFn() LessFn[int64] {
-	return func(a int64, b int64) bool {
+func (f ItemSketchLongComparator) CompareFn() CompareFn[int64] {
+	return func(a, b int64) bool {
+		if f.ReverseOrder {
+			return a > b
+		}
 		return a < b
 	}
 }
 
-func (f ArrayOfLongsSerDe) SizeOf(item int64) int {
+func (f ItemSketchLongHasher) Hash(item int64) uint64 {
+	binary.LittleEndian.PutUint64(f.scratch[:], uint64(item))
+	return murmur3.SeedSum64(_DEFAULT_SERDE_HASH_SEED, f.scratch[:])
+}
+
+func (f ItemSketchLongSerDe) SizeOf(item int64) int {
 	return 8
 }
 
-func (f ArrayOfLongsSerDe) SizeOfMany(mem []byte, offsetBytes int, numItems int) (int, error) {
+func (f ItemSketchLongSerDe) SizeOfMany(mem []byte, offsetBytes int, numItems int) (int, error) {
 	return numItems * 8, nil
 }
 
-func (f ArrayOfLongsSerDe) SerializeOneToSlice(item int64) []byte {
+func (f ItemSketchLongSerDe) SerializeOneToSlice(item int64) []byte {
 	bytes := make([]byte, 8)
 	binary.LittleEndian.PutUint64(bytes, uint64(item))
 	return bytes
 }
 
-func (f ArrayOfLongsSerDe) SerializeManyToSlice(item []int64) []byte {
+func (f ItemSketchLongSerDe) SerializeManyToSlice(item []int64) []byte {
 	if len(item) == 0 {
 		return []byte{}
 	}
@@ -68,7 +71,7 @@ func (f ArrayOfLongsSerDe) SerializeManyToSlice(item []int64) []byte {
 	return bytes
 }
 
-func (f ArrayOfLongsSerDe) DeserializeManyFromSlice(mem []byte, offsetBytes int, numItems int) ([]int64, error) {
+func (f ItemSketchLongSerDe) DeserializeManyFromSlice(mem []byte, offsetBytes int, numItems int) ([]int64, error) {
 	if numItems == 0 {
 		return []int64{}, nil
 	}

--- a/common/item_sketch_long.go
+++ b/common/item_sketch_long.go
@@ -22,17 +22,14 @@ import (
 	"github.com/twmb/murmur3"
 )
 
-type ItemSketchLongComparator struct {
-	ReverseOrder bool
-}
 type ItemSketchLongHasher struct {
 	scratch [8]byte
 }
 type ItemSketchLongSerDe struct{}
 
-func (f ItemSketchLongComparator) CompareFn() CompareFn[int64] {
+var ItemSketchLongComparator = func(reverseOrder bool) CompareFn[int64] {
 	return func(a, b int64) bool {
-		if f.ReverseOrder {
+		if reverseOrder {
 			return a > b
 		}
 		return a < b

--- a/common/item_sketch_string.go
+++ b/common/item_sketch_string.go
@@ -25,15 +25,12 @@ import (
 	"github.com/twmb/murmur3"
 )
 
-type ItemSketchStringComparator struct {
-	ReverseOrder bool
-}
 type ItemSketchStringHasher struct{}
 type ItemSketchStringSerDe struct{}
 
-func (f ItemSketchStringComparator) CompareFn() CompareFn[string] {
+var ItemSketchStringComparator = func(reverseOrder bool) CompareFn[string] {
 	return func(a, b string) bool {
-		if f.ReverseOrder {
+		if reverseOrder {
 			return a > b
 		}
 		return a < b

--- a/common/types.go
+++ b/common/types.go
@@ -19,10 +19,6 @@ package common
 
 type CompareFn[C comparable] func(C, C) bool
 
-type ItemSketchComparator[C comparable] interface {
-	CompareFn() CompareFn[C]
-}
-
 type ItemSketchHasher[C comparable] interface {
 	Hash(item C) uint64
 }

--- a/common/types.go
+++ b/common/types.go
@@ -17,12 +17,17 @@
 
 package common
 
-type LessFn[C comparable] func(C, C) bool
+type CompareFn[C comparable] func(C, C) bool
 
-type ItemSketchOp[C comparable] interface {
-	Identity() C
+type ItemSketchComparator[C comparable] interface {
+	CompareFn() CompareFn[C]
+}
+
+type ItemSketchHasher[C comparable] interface {
 	Hash(item C) uint64
-	LessFn() LessFn[C]
+}
+
+type ItemSketchSerde[C comparable] interface {
 	SizeOf(item C) int
 	SizeOfMany(mem []byte, offsetBytes int, numItems int) (int, error)
 	SerializeManyToSlice(items []C) []byte

--- a/examples/frequency_example_test.go
+++ b/examples/frequency_example_test.go
@@ -26,7 +26,7 @@ import (
 
 func TestFrequencyItemsSketch(t *testing.T) {
 	// Create a new sketch with a maximum of 16 items
-	sketch, err := frequencies.NewFrequencyItemsSketchWithMaxMapSize[string](16, common.ArrayOfStringsSerDe{})
+	sketch, err := frequencies.NewFrequencyItemsSketchWithMaxMapSize[string](16, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 
 	// Update the sketch with some items

--- a/examples/kll_example_test.go
+++ b/examples/kll_example_test.go
@@ -27,10 +27,10 @@ import (
 
 func TestKllItemsSketch(t *testing.T) {
 	// Create a comparison function for strings (or use common.ItemSketchStringComparator{})
-	comparator := common.ItemSketchStringComparator{}
+	comparator := common.ItemSketchStringComparator(false)
 
 	// Create a new KLL sketch
-	sketch, err := kll.NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	sketch, err := kll.NewKllItemsSketchWithDefault[string](comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 
 	// Update the sketch with 1000 items

--- a/examples/kll_example_test.go
+++ b/examples/kll_example_test.go
@@ -26,8 +26,11 @@ import (
 )
 
 func TestKllItemsSketch(t *testing.T) {
+	// Create a comparison function for strings (or use common.ItemSketchStringComparator{})
+	comparator := common.ItemSketchStringComparator{}
+
 	// Create a new KLL sketch
-	sketch, err := kll.NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+	sketch, err := kll.NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 
 	// Update the sketch with 1000 items

--- a/frequencies/items_sketch_test.go
+++ b/frequencies/items_sketch_test.go
@@ -26,8 +26,8 @@ import (
 )
 
 func TestEmpty(t *testing.T) {
-	h := common.ArrayOfStringsSerDe{}
-	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, h)
+	h := common.ItemSketchStringHasher{}
+	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, h, nil)
 	assert.NoError(t, err)
 	assert.True(t, sketch.IsEmpty())
 	assert.Equal(t, sketch.GetNumActiveItems(), 0)
@@ -41,7 +41,7 @@ func TestEmpty(t *testing.T) {
 }
 
 func TestOneItem(t *testing.T) {
-	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
+	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ItemSketchStringHasher{}, nil)
 	assert.NoError(t, err)
 	err = sketch.Update("a")
 	assert.NoError(t, err)
@@ -57,7 +57,7 @@ func TestOneItem(t *testing.T) {
 }
 
 func TestSeveralItem(t *testing.T) {
-	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
+	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ItemSketchStringHasher{}, nil)
 	assert.NoError(t, err)
 	err = sketch.Update("a")
 	assert.NoError(t, err)
@@ -106,7 +106,7 @@ func TestSeveralItem(t *testing.T) {
 }
 
 func TestEstimationMode(t *testing.T) {
-	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
+	sketch, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ItemSketchLongHasher{}, nil)
 	assert.NoError(t, err)
 	err = sketch.UpdateMany(1, 10)
 	assert.NoError(t, err)
@@ -165,11 +165,22 @@ func TestEstimationMode(t *testing.T) {
 	}
 }
 
-func TestSerializeStringDeserializeEmpty(t *testing.T) {
-	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
+func TestSerializeStringDeserializeNoSerde(t *testing.T) {
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ItemSketchStringHasher{}, nil)
 	assert.NoError(t, err)
-	bytes := sketch1.ToSlice()
-	sketch2, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+	_, err = sketch1.ToSlice()
+	assert.Error(t, err)
+
+	_, err = NewFrequencyItemsSketchFromSlice[string](nil, common.ItemSketchStringHasher{}, nil)
+	assert.Error(t, err)
+}
+
+func TestSerializeStringDeserializeEmpty(t *testing.T) {
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
+	assert.NoError(t, err)
+	bytes, err := sketch1.ToSlice()
+	assert.NoError(t, err)
+	sketch2, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	assert.True(t, sketch2.IsEmpty())
 	assert.Equal(t, sketch2.GetNumActiveItems(), 0)
@@ -177,7 +188,7 @@ func TestSerializeStringDeserializeEmpty(t *testing.T) {
 }
 
 func TestSerializeDeserializeUtf8Strings(t *testing.T) {
-	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	err = sketch1.Update("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa")
 	assert.NoError(t, err)
@@ -188,8 +199,9 @@ func TestSerializeDeserializeUtf8Strings(t *testing.T) {
 	err = sketch1.Update("ddddddddddddddddddddddddddddd")
 	assert.NoError(t, err)
 
-	bytes := sketch1.ToSlice()
-	sketch2, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+	bytes, err := sketch1.ToSlice()
+	assert.NoError(t, err)
+	sketch2, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	err = sketch2.Update("bbbbbbbbbbbbbbbbbbbbbbbbbbbbb")
 	assert.NoError(t, err)
@@ -216,14 +228,15 @@ func TestSerializeDeserializeUtf8Strings(t *testing.T) {
 }
 
 func TestSerializeDeserializeLong(t *testing.T) {
-	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ItemSketchLongHasher{}, common.ItemSketchLongSerDe{})
 	sketch1.Update(1)
 	sketch1.Update(2)
 	sketch1.Update(3)
 	sketch1.Update(4)
 
-	bytes := sketch1.ToSlice()
-	sketch2, err := NewFrequencyItemsSketchFromSlice[int64](bytes, common.ArrayOfLongsSerDe{})
+	bytes, err := sketch1.ToSlice()
+	assert.NoError(t, err)
+	sketch2, err := NewFrequencyItemsSketchFromSlice[int64](bytes, common.ItemSketchLongHasher{}, common.ItemSketchLongSerDe{})
 	sketch2.Update(2)
 	sketch2.Update(3)
 	sketch2.Update(2)
@@ -246,7 +259,7 @@ func TestSerializeDeserializeLong(t *testing.T) {
 }
 
 func TestResize(t *testing.T) {
-	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](2<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](2<<_LG_MIN_MAP_SIZE, common.ItemSketchStringHasher{}, nil)
 	for i := 0; i < 32; i++ {
 		err = sketch1.UpdateMany(strconv.Itoa(i), int64(i*i))
 		assert.NoError(t, err)
@@ -254,7 +267,7 @@ func TestResize(t *testing.T) {
 }
 
 func TestMergeExact(t *testing.T) {
-	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ItemSketchStringHasher{}, nil)
 	assert.NoError(t, err)
 	err = sketch1.Update("a")
 	assert.NoError(t, err)
@@ -265,7 +278,7 @@ func TestMergeExact(t *testing.T) {
 	err = sketch1.Update("d")
 	assert.NoError(t, err)
 
-	sketch2, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
+	sketch2, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ItemSketchStringHasher{}, nil)
 	assert.NoError(t, err)
 	err = sketch2.Update("b")
 	assert.NoError(t, err)
@@ -294,20 +307,20 @@ func TestMergeExact(t *testing.T) {
 }
 
 func TestNullMapReturns(t *testing.T) {
-	map1, err := newReversePurgeItemHashMap[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
+	map1, err := newReversePurgeItemHashMap[int64](1<<_LG_MIN_MAP_SIZE, common.ItemSketchLongHasher{}, nil)
 	assert.NoError(t, err)
 	assert.Nil(t, map1.getActiveKeys())
 	assert.Nil(t, map1.getActiveValues())
 }
 
 func TestMisc(t *testing.T) {
-	sk1, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
+	sk1, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ItemSketchLongHasher{}, nil)
 	assert.NoError(t, err)
 	assert.Equal(t, sk1.GetCurrentMapCapacity(), 6)
 	est, err := sk1.GetEstimate(1)
 	assert.NoError(t, err)
 	assert.Equal(t, est, int64(0))
-	sk2, err := NewFrequencyItemsSketchWithMaxMapSize[int64](8, common.ArrayOfLongsSerDe{})
+	sk2, err := NewFrequencyItemsSketchWithMaxMapSize[int64](8, common.ItemSketchLongHasher{}, nil)
 	assert.NoError(t, err)
 	_, err = sk1.Merge(sk2)
 	assert.NoError(t, err)
@@ -328,14 +341,14 @@ func TestMisc(t *testing.T) {
 }
 
 func TestToString(t *testing.T) {
-	sk, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
+	sk, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ItemSketchLongHasher{}, nil)
 	assert.NoError(t, err)
 	err = sk.Update(1)
 	t.Log(sk.ToString())
 }
 
 func TestFrequentItems1(t *testing.T) {
-	fis, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
+	fis, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ItemSketchLongHasher{}, nil)
 	assert.NoError(t, err)
 	fis.Update(1)
 	rows, err := fis.GetFrequentItems(ErrorTypeEnum.NoFalsePositives)
@@ -352,17 +365,18 @@ func TestFrequentItems1(t *testing.T) {
 }
 
 func TestUpdateExceptions(t *testing.T) {
-	sk1, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
+	sk1, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ItemSketchLongHasher{}, nil)
 	assert.NoError(t, err)
 	err = sk1.UpdateMany(1, -1)
 	assert.Error(t, err)
 }
 
 func TestMemExceptions(t *testing.T) {
-	sk1, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ArrayOfLongsSerDe{})
+	sk1, err := NewFrequencyItemsSketchWithMaxMapSize[int64](1<<_LG_MIN_MAP_SIZE, common.ItemSketchLongHasher{}, common.ItemSketchLongSerDe{})
 	assert.NoError(t, err)
 	sk1.Update(1)
-	bytes := sk1.ToSlice()
+	bytes, err := sk1.ToSlice()
+	assert.NoError(t, err)
 	pre0 := binary.LittleEndian.Uint64(bytes)
 	//Now start corrupting
 	tryBadMem(t, bytes, _PREAMBLE_LONGS_BYTE, 2) //Corrupt
@@ -379,7 +393,7 @@ func TestMemExceptions(t *testing.T) {
 }
 
 func TestOneItemUtf8(t *testing.T) {
-	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ArrayOfStringsSerDe{})
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](1<<_LG_MIN_MAP_SIZE, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	err = sketch1.Update("\u5fb5")
 	assert.NoError(t, err)
@@ -390,8 +404,9 @@ func TestOneItemUtf8(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, est, int64(1))
 
-	bytes := sketch1.ToSlice()
-	sketch2, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+	bytes, err := sketch1.ToSlice()
+	assert.NoError(t, err)
+	sketch2, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	assert.False(t, sketch2.IsEmpty())
 	assert.Equal(t, sketch2.GetNumActiveItems(), 1)
@@ -418,7 +433,7 @@ func TestItemGetAprioriError(t *testing.T) {
 }
 
 func BenchmarkItemSketch(b *testing.B) {
-	sketch, err := NewFrequencyItemsSketch[int64](128, 8, common.ArrayOfLongsSerDe{})
+	sketch, err := NewFrequencyItemsSketch[int64](128, 8, common.ItemSketchLongHasher{}, nil)
 	assert.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		sketch.Update(int64(i))

--- a/frequencies/serde_compat_test.go
+++ b/frequencies/serde_compat_test.go
@@ -24,14 +24,15 @@ import (
 )
 
 func TestItemsToLongs(t *testing.T) {
-	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[int64](8, common.ArrayOfLongsSerDe{})
+	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[int64](8, common.ItemSketchLongHasher{}, common.ItemSketchLongSerDe{})
 	assert.NoError(t, err)
 	sketch1.Update(1)
 	sketch1.Update(2)
 	sketch1.Update(3)
 	sketch1.Update(4)
 
-	bytes := sketch1.ToSlice()
+	bytes, err := sketch1.ToSlice()
+	assert.NoError(t, err)
 	sketch2, err := NewLongsSketchFromSlice(bytes)
 	assert.NoError(t, err)
 	sketch2.Update(2)
@@ -64,7 +65,7 @@ func TestLongToItems(t *testing.T) {
 	sketch1.Update(4)
 
 	bytes := sketch1.ToSlice()
-	sketch2, err := NewFrequencyItemsSketchFromSlice[int64](bytes, common.ArrayOfLongsSerDe{})
+	sketch2, err := NewFrequencyItemsSketchFromSlice[int64](bytes, common.ItemSketchLongHasher{}, common.ItemSketchLongSerDe{})
 	assert.NoError(t, err)
 	sketch2.Update(2)
 	sketch2.Update(3)

--- a/frequencies/sketch_serialization_test.go
+++ b/frequencies/sketch_serialization_test.go
@@ -66,7 +66,7 @@ func TestGenerateGoBinariesForCompatibilityTestingLongsSketch(t *testing.T) {
 	t.Run("String Frequency", func(t *testing.T) {
 		nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range nArr {
-			sk, err := NewFrequencyItemsSketchWithMaxMapSize[string](64, common.ArrayOfStringsSerDe{})
+			sk, err := NewFrequencyItemsSketchWithMaxMapSize[string](64, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 			assert.NoError(t, err)
 			for i := 1; i <= n; i++ {
 				err = sk.Update(strconv.Itoa(i))
@@ -85,7 +85,7 @@ func TestGenerateGoBinariesForCompatibilityTestingLongsSketch(t *testing.T) {
 			err = os.MkdirAll(internal.GoPath, os.ModePerm)
 			assert.NoError(t, err)
 
-			slc := sk.ToSlice()
+			slc, err := sk.ToSlice()
 			err = os.WriteFile(fmt.Sprintf("%s/frequent_string_n%d_go.sk", internal.GoPath, n), slc, 0644)
 			if err != nil {
 				t.Errorf("err != nil")
@@ -94,7 +94,7 @@ func TestGenerateGoBinariesForCompatibilityTestingLongsSketch(t *testing.T) {
 	})
 
 	t.Run("String ut8", func(t *testing.T) {
-		sk, err := NewFrequencyItemsSketchWithMaxMapSize[string](64, common.ArrayOfStringsSerDe{})
+		sk, err := NewFrequencyItemsSketchWithMaxMapSize[string](64, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 		assert.NoError(t, err)
 
 		assert.NoError(t, sk.UpdateMany("абвгд", 1))
@@ -108,7 +108,7 @@ func TestGenerateGoBinariesForCompatibilityTestingLongsSketch(t *testing.T) {
 		err = os.MkdirAll(internal.GoPath, os.ModePerm)
 		assert.NoError(t, err)
 
-		slc := sk.ToSlice()
+		slc, err := sk.ToSlice()
 		err = os.WriteFile(fmt.Sprintf("%s/frequent_string_utf8_go.sk", internal.GoPath), slc, 0644)
 		if err != nil {
 			t.Errorf("err != nil")
@@ -116,7 +116,7 @@ func TestGenerateGoBinariesForCompatibilityTestingLongsSketch(t *testing.T) {
 	})
 
 	t.Run("String ascii", func(t *testing.T) {
-		sk, err := NewFrequencyItemsSketchWithMaxMapSize[string](64, common.ArrayOfStringsSerDe{})
+		sk, err := NewFrequencyItemsSketchWithMaxMapSize[string](64, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 		assert.NoError(t, err)
 
 		assert.NoError(t, sk.UpdateMany("aaaaaaaaaaaaaaaaaaaaaaaaaaaaa", 1))
@@ -127,7 +127,7 @@ func TestGenerateGoBinariesForCompatibilityTestingLongsSketch(t *testing.T) {
 		err = os.MkdirAll(internal.GoPath, os.ModePerm)
 		assert.NoError(t, err)
 
-		slc := sk.ToSlice()
+		slc, err := sk.ToSlice()
 		err = os.WriteFile(fmt.Sprintf("%s/frequent_string_ascii_go.sk", internal.GoPath), slc, 0644)
 		if err != nil {
 			t.Errorf("err != nil")
@@ -166,7 +166,7 @@ func TestJavaCompat(t *testing.T) {
 		for _, n := range nArr {
 			bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_n%d_java.sk", internal.JavaPath, n))
 			assert.NoError(t, err)
-			sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+			sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 			if err != nil {
 				return
 			}
@@ -188,7 +188,7 @@ func TestJavaCompat(t *testing.T) {
 	t.Run("String utf8", func(t *testing.T) {
 		bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_utf8_java.sk", internal.JavaPath))
 		assert.NoError(t, err)
-		sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+		sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 		if err != nil {
 			return
 		}
@@ -221,7 +221,7 @@ func TestJavaCompat(t *testing.T) {
 	t.Run("String ascii", func(t *testing.T) {
 		bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_ascii_java.sk", internal.JavaPath))
 		assert.NoError(t, err)
-		sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+		sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 		if err != nil {
 			return
 		}
@@ -273,7 +273,7 @@ func TestCppCompat(t *testing.T) {
 		for _, n := range nArr {
 			bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_n%d_cpp.sk", internal.CppPath, n))
 			assert.NoError(t, err)
-			sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+			sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 			if err != nil {
 				return
 			}
@@ -295,7 +295,7 @@ func TestCppCompat(t *testing.T) {
 	t.Run("String utf8", func(t *testing.T) {
 		bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_utf8_cpp.sk", internal.CppPath))
 		assert.NoError(t, err)
-		sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+		sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 		if err != nil {
 			return
 		}
@@ -328,7 +328,7 @@ func TestCppCompat(t *testing.T) {
 	t.Run("String ascii", func(t *testing.T) {
 		bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_ascii_cpp.sk", internal.CppPath))
 		assert.NoError(t, err)
-		sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ArrayOfStringsSerDe{})
+		sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 		if err != nil {
 			return
 		}

--- a/internal/generic_inequality_search.go
+++ b/internal/generic_inequality_search.go
@@ -30,7 +30,7 @@ const (
 	InequalityGT
 )
 
-func FindWithInequality[C comparable](arr []C, low int, high int, v C, crit Inequality, lessFn common.LessFn[C]) int {
+func FindWithInequality[C comparable](arr []C, low int, high int, v C, crit Inequality, comparator common.CompareFn[C]) int {
 	if len(arr) == 0 {
 		return -1
 	}
@@ -38,35 +38,35 @@ func FindWithInequality[C comparable](arr []C, low int, high int, v C, crit Ineq
 	hi := high
 	for lo <= hi {
 		if hi-lo <= 1 {
-			return resolve(arr, lo, hi, v, crit, lessFn)
+			return resolve(arr, lo, hi, v, crit, comparator)
 		}
 		mid := lo + (hi-lo)/2
-		ret := compare(arr, mid, mid+1, v, crit, lessFn)
+		ret := compare(arr, mid, mid+1, v, crit, comparator)
 		if ret == -1 {
 			hi = mid
 		} else if ret == 1 {
 			lo = mid + 1
 		} else {
-			return getIndex(arr, mid, mid+1, v, crit, lessFn)
+			return getIndex(arr, mid, mid+1, v, crit, comparator)
 		}
 	}
 	return -1
 }
 
-func resolve[C comparable](arr []C, lo int, hi int, v C, crit Inequality, lessFn common.LessFn[C]) int {
+func resolve[C comparable](arr []C, lo int, hi int, v C, crit Inequality, compareFn common.CompareFn[C]) int {
 	result := 0
 	switch crit {
 	case InequalityLT:
 		if lo == hi {
-			if lessFn(v, arr[hi]) == false && v != arr[hi] {
+			if compareFn(v, arr[hi]) == false && v != arr[hi] {
 				result = lo
 			} else {
 				result = -1
 			}
 		} else {
-			if lessFn(v, arr[hi]) == false && v != arr[hi] {
+			if compareFn(v, arr[hi]) == false && v != arr[hi] {
 				result = hi
-			} else if lessFn(v, arr[lo]) == false && v != arr[lo] {
+			} else if compareFn(v, arr[lo]) == false && v != arr[lo] {
 				result = lo
 			} else {
 				result = -1
@@ -74,15 +74,15 @@ func resolve[C comparable](arr []C, lo int, hi int, v C, crit Inequality, lessFn
 		}
 	case InequalityLE:
 		if lo == hi {
-			if lessFn(v, arr[lo]) == false {
+			if compareFn(v, arr[lo]) == false {
 				result = lo
 			} else {
 				result = -1
 			}
 		} else {
-			if lessFn(v, arr[hi]) == false {
+			if compareFn(v, arr[hi]) == false {
 				result = hi
-			} else if lessFn(v, arr[lo]) == false {
+			} else if compareFn(v, arr[lo]) == false {
 				result = lo
 			} else {
 				result = -1
@@ -91,15 +91,15 @@ func resolve[C comparable](arr []C, lo int, hi int, v C, crit Inequality, lessFn
 
 	case InequalityGE:
 		if lo == hi {
-			if lessFn(v, arr[lo]) || v == arr[lo] {
+			if compareFn(v, arr[lo]) || v == arr[lo] {
 				result = lo
 			} else {
 				result = -1
 			}
 		} else {
-			if lessFn(v, arr[lo]) || v == arr[lo] {
+			if compareFn(v, arr[lo]) || v == arr[lo] {
 				result = lo
-			} else if lessFn(v, arr[hi]) || v == arr[hi] {
+			} else if compareFn(v, arr[hi]) || v == arr[hi] {
 				result = hi
 			} else {
 				result = -1
@@ -107,15 +107,15 @@ func resolve[C comparable](arr []C, lo int, hi int, v C, crit Inequality, lessFn
 		}
 	case InequalityGT:
 		if lo == hi {
-			if lessFn(v, arr[lo]) {
+			if compareFn(v, arr[lo]) {
 				result = lo
 			} else {
 				result = -1
 			}
 		} else {
-			if lessFn(v, arr[lo]) {
+			if compareFn(v, arr[lo]) {
 				result = lo
-			} else if lessFn(v, arr[hi]) {
+			} else if compareFn(v, arr[hi]) {
 				result = hi
 			} else {
 				result = -1
@@ -128,21 +128,21 @@ func resolve[C comparable](arr []C, lo int, hi int, v C, crit Inequality, lessFn
 	return result
 }
 
-func compare[C comparable](arr []C, a int, b int, v C, crit Inequality, lessFn common.LessFn[C]) int {
+func compare[C comparable](arr []C, a int, b int, v C, crit Inequality, compareFn common.CompareFn[C]) int {
 	result := 0
 	switch crit {
 	case InequalityLT, InequalityGE:
-		if lessFn(v, arr[a]) || arr[a] == v {
+		if compareFn(v, arr[a]) || arr[a] == v {
 			result = -1
-		} else if lessFn(arr[b], v) {
+		} else if compareFn(arr[b], v) {
 			result = 1
 		} else {
 			result = 0
 		}
 	case InequalityLE, InequalityGT:
-		if lessFn(v, arr[a]) {
+		if compareFn(v, arr[a]) {
 			result = -1
-		} else if lessFn(arr[b], v) || arr[b] == v {
+		} else if compareFn(arr[b], v) || arr[b] == v {
 			result = 1
 		} else {
 			result = 0
@@ -153,7 +153,7 @@ func compare[C comparable](arr []C, a int, b int, v C, crit Inequality, lessFn c
 	return result
 }
 
-func getIndex[C comparable](arr []C, a int, b int, v C, crit Inequality, lessFn common.LessFn[C]) int {
+func getIndex[C comparable](arr []C, a int, b int, v C, crit Inequality, compareFn common.CompareFn[C]) int {
 	result := 0
 	switch crit {
 	case InequalityLT, InequalityLE:

--- a/kll/items_sketch_iterator.go
+++ b/kll/items_sketch_iterator.go
@@ -27,7 +27,7 @@ type ItemsSketchIterator[C comparable] struct {
 	level         int
 	weight        int64
 	isInitialized bool
-	itemsSketchOp common.ItemSketchOp[C]
+	itemsSketchOp common.ItemSketchSerde[C]
 }
 
 func newItemsSketchIterator[C comparable](

--- a/kll/items_sketch_test.go
+++ b/kll/items_sketch_test.go
@@ -22,6 +22,9 @@ import (
 	"github.com/apache/datasketches-go/common"
 	"github.com/stretchr/testify/assert"
 	"math"
+	"math/rand"
+	"strconv"
+	"strings"
 	"testing"
 )
 
@@ -32,16 +35,18 @@ const (
 )
 
 func TestItemsSketch_KLimits(t *testing.T) {
-	_, err := NewKllItemsSketch[string](_MIN_K, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	_, err := NewKllItemsSketch[string](_MIN_K, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	_, err = NewKllItemsSketch[string](uint16(_MAX_K), _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	_, err = NewKllItemsSketch[string](uint16(_MAX_K), _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	_, err = NewKllItemsSketch[string](_MIN_K-1, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	_, err = NewKllItemsSketch[string](_MIN_K-1, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.Error(t, err)
 }
 
 func TestItemsSketch_Empty(t *testing.T) {
-	sketch, err := NewKllItemsSketch[string](200, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch, err := NewKllItemsSketch[string](200, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	assert.True(t, sketch.IsEmpty())
 	assert.False(t, sketch.IsEstimationMode())
@@ -63,7 +68,8 @@ func TestItemsSketch_Empty(t *testing.T) {
 }
 
 func TestItemsSketch_BadQuantile(t *testing.T) {
-	sketch, err := NewKllItemsSketch[string](200, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch, err := NewKllItemsSketch[string](200, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sketch.Update("") // has to be non-empty to reach the check
 	_, err = sketch.GetQuantile(-1, true)
@@ -71,7 +77,8 @@ func TestItemsSketch_BadQuantile(t *testing.T) {
 }
 
 func TestItemsSketch_OneValue(t *testing.T) {
-	sketch, err := NewKllItemsSketch[string](200, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch, err := NewKllItemsSketch[string](200, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sketch.Update("A")
 	assert.False(t, sketch.IsEmpty())
@@ -100,8 +107,9 @@ func TestItemsSketch_OneValue(t *testing.T) {
 }
 
 func TestItemsSketch_TenValues(t *testing.T) {
+	comparator := common.ItemSketchStringComparator{}
 	tenStr := []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J"}
-	sketch, err := NewKllItemsSketch[string](20, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	sketch, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	strLen := len(tenStr)
 	dblStrLen := float64(strLen)
@@ -176,7 +184,8 @@ func TestItemsSketch_TenValues(t *testing.T) {
 }
 
 func TestItemsSketch_ManyValuesEstimationMode(T *testing.T) {
-	sketch, err := NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(T, err)
 	n := 1_000_000
 	digits := numDigits(n)
@@ -236,7 +245,8 @@ func TestItemsSketch_ManyValuesEstimationMode(T *testing.T) {
 }
 
 func TestItemsSketch_GetRankGetCdfGetPmfConsistency(t *testing.T) {
-	sketch, err := NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 1000
 	digits := numDigits(n)
@@ -283,9 +293,10 @@ func TestItemsSketch_GetRankGetCdfGetPmfConsistency(t *testing.T) {
 }
 
 func TestItemsSketch_Merge(t *testing.T) {
-	sketch1, err := NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch1, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	sketch2, err := NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+	sketch2, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 10000
 	digits := numDigits(2 * n)
@@ -326,9 +337,10 @@ func TestItemsSketch_Merge(t *testing.T) {
 }
 
 func TestItemsSketch_MergeLowerK(t *testing.T) {
-	sketch1, err := NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch1, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	sketch2, err := NewKllItemsSketch[string](_DEFAULT_K/2, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	sketch2, err := NewKllItemsSketch[string](_DEFAULT_K/2, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 10000
 	digits := numDigits(2 * n)
@@ -374,9 +386,10 @@ func TestItemsSketch_MergeLowerK(t *testing.T) {
 }
 
 func TestItemsSketch_MergeEmptyLowerK(t *testing.T) {
-	sketch1, err := NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch1, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	sketch2, err := NewKllItemsSketch[string](_DEFAULT_K/2, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	sketch2, err := NewKllItemsSketch[string](_DEFAULT_K/2, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 10000
 	digits := numDigits(n)
@@ -435,9 +448,10 @@ func TestItemsSketch_MergeEmptyLowerK(t *testing.T) {
 }
 
 func TestItemsSketch_MergeExactModeLowerK(t *testing.T) {
-	sketch1, err := NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch1, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	sketch2, err := NewKllItemsSketch[string](_DEFAULT_K/2, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	sketch2, err := NewKllItemsSketch[string](_DEFAULT_K/2, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 10000
 	digits := numDigits(n)
@@ -453,9 +467,10 @@ func TestItemsSketch_MergeExactModeLowerK(t *testing.T) {
 }
 
 func TestItemsSketch_MergeMinMinValueFromOther(t *testing.T) {
-	sketch1, err := NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch1, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	sketch2, err := NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+	sketch2, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sketch1.Update(intToFixedLengthString(1, 1))
 	sketch2.Update(intToFixedLengthString(2, 1))
@@ -466,9 +481,10 @@ func TestItemsSketch_MergeMinMinValueFromOther(t *testing.T) {
 }
 
 func TestItemsSketch_MergeMinAndMaxFromOther(t *testing.T) {
-	sketch1, err := NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch1, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	sketch2, err := NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+	sketch2, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 1_000_000
 	digits := numDigits(n)
@@ -485,12 +501,14 @@ func TestItemsSketch_MergeMinAndMaxFromOther(t *testing.T) {
 }
 
 func TestItemsSketch_KTooSmall(t *testing.T) {
-	_, err := NewKllItemsSketch[string](_MIN_K-1, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	_, err := NewKllItemsSketch[string](_MIN_K-1, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.Error(t, err)
 }
 
 func TestItemsSketch_MinK(t *testing.T) {
-	sketch, err := NewKllItemsSketch[string](uint16(8), _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch, err := NewKllItemsSketch[string](uint16(8), _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 1000
 	digits := numDigits(n)
@@ -507,7 +525,8 @@ func TestItemsSketch_MinK(t *testing.T) {
 }
 
 func TestItemsSketch_MaxK(t *testing.T) {
-	sketch, err := NewKllItemsSketch[string](uint16(_MAX_K), _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch, err := NewKllItemsSketch[string](uint16(_MAX_K), _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 1000
 	digits := numDigits(n)
@@ -524,7 +543,8 @@ func TestItemsSketch_MaxK(t *testing.T) {
 }
 
 func TestItemsSketch_OutOfOrderSplitPoints(t *testing.T) {
-	sketch, err := NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	s0 := intToFixedLengthString(0, 1)
 	s1 := intToFixedLengthString(1, 1)
@@ -534,7 +554,8 @@ func TestItemsSketch_OutOfOrderSplitPoints(t *testing.T) {
 }
 
 func TestItemsSketch_DuplicateSplitPoints(t *testing.T) {
-	sketch, err := NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sketch.Update("A")
 	sketch.Update("B")
@@ -549,7 +570,8 @@ func TestItemsSketch_DuplicateSplitPoints(t *testing.T) {
 }
 
 func TestItemsSketch_CheckReset(t *testing.T) {
-	sketch, err := NewKllItemsSketch[string](20, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 100
 	digits := numDigits(n)
@@ -576,7 +598,8 @@ func TestItemsSketch_CheckReset(t *testing.T) {
 }
 
 func TestItemsSketch_SortedView(t *testing.T) {
-	sketch, err := NewKllItemsSketch[string](20, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sketch, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sketch.Update("A")
 	sketch.Update("AB")
@@ -604,12 +627,13 @@ func TestItemsSketch_SortedView(t *testing.T) {
 }
 
 func TestItemsSketch_CDF_PDF(t *testing.T) {
+	comparator := common.ItemSketchStringComparator{}
 	cdfI := []float64{.25, .50, .75, 1.0, 1.0}
 	cdfE := []float64{0.0, .25, .50, .75, 1.0}
 	pmfI := []float64{.25, .25, .25, .25, 0.0}
 	pmfE := []float64{0.0, .25, .25, .25, .25}
 	toll := 1e-10
-	sketch, err := NewKllItemsSketch[string](20, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	sketch, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	strIn := []string{"A", "AB", "ABC", "ABCD"}
 	for i := 0; i < len(strIn); i++ {
@@ -646,17 +670,18 @@ func TestItemsSketch_CDF_PDF(t *testing.T) {
 }
 
 func TestItemsSketch_DeserializeEmpty(t *testing.T) {
-	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	mem, err := sk1.ToSlice()
 	assert.NoError(t, err)
 	assert.NotNil(t, mem)
-	memVal, err := newItemsSketchMemoryValidate[string](mem, common.ArrayOfStringsSerDe{})
+	memVal, err := newItemsSketchMemoryValidate[string](mem, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	assert.Equal(t, memVal.sketchStructure, _COMPACT_EMPTY)
 	assert.Equal(t, len(mem), 8)
 
-	sk2, err := NewKllItemsSketchFromSlice[string](mem, common.ArrayOfStringsSerDe{})
+	sk2, err := NewKllItemsSketchFromSlice[string](mem, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	assert.Equal(t, sk2.GetN(), uint64(0))
 	_, err = sk2.GetMinItem()
@@ -666,16 +691,17 @@ func TestItemsSketch_DeserializeEmpty(t *testing.T) {
 }
 
 func TestItemsSketch_DeserializeSingleItem(t *testing.T) {
-	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sk1.Update("A")
 	mem, err := sk1.ToSlice()
 	assert.NoError(t, err)
 	assert.NotNil(t, mem)
-	memVal, err := newItemsSketchMemoryValidate[string](mem, common.ArrayOfStringsSerDe{})
+	memVal, err := newItemsSketchMemoryValidate[string](mem, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	assert.Equal(t, memVal.sketchStructure, _COMPACT_SINGLE)
-	sk2, err := NewKllItemsSketchFromSlice[string](mem, common.ArrayOfStringsSerDe{})
+	sk2, err := NewKllItemsSketchFromSlice[string](mem, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	assert.Equal(t, sk2.GetN(), uint64(1))
 	minV, err := sk2.GetMinItem()
@@ -687,7 +713,8 @@ func TestItemsSketch_DeserializeSingleItem(t *testing.T) {
 }
 
 func TestItemsSketch_FewItems(t *testing.T) {
-	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sk1.Update("A")
 	sk1.Update("AB")
@@ -695,14 +722,15 @@ func TestItemsSketch_FewItems(t *testing.T) {
 	mem, err := sk1.ToSlice()
 	assert.NoError(t, err)
 	assert.NotNil(t, mem)
-	memVal, err := newItemsSketchMemoryValidate[string](mem, common.ArrayOfStringsSerDe{})
+	memVal, err := newItemsSketchMemoryValidate[string](mem, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	assert.Equal(t, memVal.sketchStructure, _COMPACT_FULL)
 	assert.Equal(t, len(mem), memVal.sketchBytes)
 }
 
 func TestItemsSketch_ManyItems(t *testing.T) {
-	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 109
 	digits := numDigits(n)
@@ -712,14 +740,15 @@ func TestItemsSketch_ManyItems(t *testing.T) {
 	mem, err := sk1.ToSlice()
 	assert.NoError(t, err)
 	assert.NotNil(t, mem)
-	memVal, err := newItemsSketchMemoryValidate[string](mem, common.ArrayOfStringsSerDe{})
+	memVal, err := newItemsSketchMemoryValidate[string](mem, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	assert.Equal(t, memVal.sketchStructure, _COMPACT_FULL)
 	assert.Equal(t, len(mem), memVal.sketchBytes)
 }
 
 func TestItemsSketch_SortedViewAfterReset(t *testing.T) {
-	sk, err := NewKllItemsSketch[string](20, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sk, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sk.Update("1")
 	sv, err := sk.GetSortedView()
@@ -733,12 +762,13 @@ func TestItemsSketch_SortedViewAfterReset(t *testing.T) {
 }
 
 func TestItemsSketch_SerializeDeserializeEmpty(t *testing.T) {
-	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	mem, err := sk1.ToSlice()
 	assert.NoError(t, err)
 	assert.NotNil(t, mem)
-	sk2, err := NewKllItemsSketchFromSlice[string](mem, common.ArrayOfStringsSerDe{})
+	sk2, err := NewKllItemsSketchFromSlice[string](mem, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	s, err := sk1.GetSerializedSizeBytes()
 	assert.NoError(t, err)
@@ -762,13 +792,14 @@ func TestItemsSketch_SerializeDeserializeEmpty(t *testing.T) {
 }
 
 func TestItemsSketch_SerializeDeserializeOneValue(t *testing.T) {
-	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sk1.Update(" 1")
 	mem, err := sk1.ToSlice()
 	assert.NoError(t, err)
 	assert.NotNil(t, mem)
-	sk2, err := NewKllItemsSketchFromSlice[string](mem, common.ArrayOfStringsSerDe{})
+	sk2, err := NewKllItemsSketchFromSlice[string](mem, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	s1SizeBytes, err := sk1.GetSerializedSizeBytes()
 	assert.Equal(t, len(mem), s1SizeBytes)
@@ -793,7 +824,8 @@ func TestItemsSketch_SerializeDeserializeOneValue(t *testing.T) {
 }
 
 func TestItemsSketch_SerializeDeserializeMultipleValue(t *testing.T) {
-	sk1, err := NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+	comparator := common.ItemSketchStringComparator{}
+	sk1, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 1000
 	for i := 0; i < n; i++ {
@@ -808,7 +840,7 @@ func TestItemsSketch_SerializeDeserializeMultipleValue(t *testing.T) {
 	mem, err := sk1.ToSlice()
 	assert.NoError(t, err)
 	assert.NotNil(t, mem)
-	sk2, err := NewKllItemsSketchFromSlice[string](mem, common.ArrayOfStringsSerDe{})
+	sk2, err := NewKllItemsSketchFromSlice[string](mem, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	s1, err := sk2.GetSerializedSizeBytes()
 	assert.NoError(t, err)
@@ -832,10 +864,10 @@ func TestItemsSketch_SerializeDeserializeMultipleValue(t *testing.T) {
 
 func TestSerializeDeserializeString(t *testing.T) {
 	nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
-	serde := common.ArrayOfStringsSerDe{}
+	comparator := common.ItemSketchStringComparator{}
 	for _, n := range nArr {
 		digits := numDigits(n)
-		sk, err := NewKllItemsSketchWithDefault[string](serde)
+		sk, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
 		assert.NoError(t, err)
 		for i := 1; i <= n; i++ {
 			sk.Update(intToFixedLengthString(i, digits))
@@ -843,7 +875,7 @@ func TestSerializeDeserializeString(t *testing.T) {
 		slc, err := sk.ToSlice()
 		assert.NoError(t, err)
 
-		sketch, err := NewKllItemsSketchFromSlice[string](slc, serde)
+		sketch, err := NewKllItemsSketchFromSlice[string](slc, comparator.CompareFn(), common.ItemSketchStringSerDe{})
 		if err != nil {
 			return
 		}
@@ -872,11 +904,11 @@ func TestSerializeDeserializeString(t *testing.T) {
 
 			weight := int64(0)
 			it := sketch.GetIterator()
-			lessFn := serde.LessFn()
+			compareFn := comparator.CompareFn()
 			for it.Next() {
 				qut := it.GetQuantile()
-				assert.True(t, lessFn(minV, qut) || minV == qut, fmt.Sprintf("min: \"%v\" \"%v\"", minV, qut))
-				assert.True(t, !lessFn(maxV, qut) || maxV == qut, fmt.Sprintf("max: \"%v\" \"%v\"", maxV, qut))
+				assert.True(t, compareFn(minV, qut) || minV == qut, fmt.Sprintf("min: \"%v\" \"%v\"", minV, qut))
+				assert.True(t, !compareFn(maxV, qut) || maxV == qut, fmt.Sprintf("max: \"%v\" \"%v\"", maxV, qut))
 				weight += it.GetWeight()
 			}
 			assert.Equal(t, weight, int64(n))
@@ -886,9 +918,9 @@ func TestSerializeDeserializeString(t *testing.T) {
 
 func TestSerializeDeserializeFloat(t *testing.T) {
 	nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
-	serde := common.ArrayOfDoublesSerDe{}
+	comparator := common.ItemSketchDoubleComparator{}
 	for _, n := range nArr {
-		sk, err := NewKllItemsSketchWithDefault[float64](serde)
+		sk, err := NewKllItemsSketchWithDefault[float64](comparator.CompareFn(), common.ItemSketchDoubleSerDe{})
 		assert.NoError(t, err)
 		for i := 1; i <= n; i++ {
 			sk.Update(float64(i))
@@ -896,7 +928,7 @@ func TestSerializeDeserializeFloat(t *testing.T) {
 		slc, err := sk.ToSlice()
 		assert.NoError(t, err)
 
-		sketch, err := NewKllItemsSketchFromSlice[float64](slc, serde)
+		sketch, err := NewKllItemsSketchFromSlice[float64](slc, comparator.CompareFn(), common.ItemSketchDoubleSerDe{})
 		if err != nil {
 			return
 		}
@@ -925,14 +957,62 @@ func TestSerializeDeserializeFloat(t *testing.T) {
 
 			weight := int64(0)
 			it := sketch.GetIterator()
-			lessFn := serde.LessFn()
+			compareFn := comparator.CompareFn()
 			for it.Next() {
 				qut := it.GetQuantile()
-				assert.True(t, lessFn(minV, qut) || minV == qut, fmt.Sprintf("min: \"%v\" \"%v\"", minV, qut))
-				assert.True(t, !lessFn(maxV, qut) || maxV == qut, fmt.Sprintf("max: \"%v\" \"%v\"", maxV, qut))
+				assert.True(t, compareFn(minV, qut) || minV == qut, fmt.Sprintf("min: \"%v\" \"%v\"", minV, qut))
+				assert.True(t, !compareFn(maxV, qut) || maxV == qut, fmt.Sprintf("max: \"%v\" \"%v\"", maxV, qut))
 				weight += it.GetWeight()
 			}
 			assert.Equal(t, weight, int64(n))
+		}
+	}
+}
+
+func TestSerializeStringDeserializeNoSerde(t *testing.T) {
+	comparator := common.ItemSketchStringComparator{}
+	sketch1, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), nil)
+	assert.NoError(t, err)
+	_, err = sketch1.ToSlice()
+	assert.Error(t, err)
+
+	_, err = NewKllItemsSketchFromSlice[string](nil, comparator.CompareFn(), nil)
+	assert.Error(t, err)
+}
+
+func TestNoCompare(t *testing.T) {
+	_, err := NewKllItemsSketchWithDefault[string](nil, nil)
+	assert.Error(t, err)
+}
+
+// There is no guarantee that L0 is sorted after a merge.
+// The issue is, during a merge, L0 must be sorted prior to a compaction to a higher level.
+// Otherwise the higher levels would not be sorted properly.
+func TestL0SortDuringMerge(t *testing.T) {
+	comparator := common.ItemSketchStringComparator{
+		ReverseOrder: true,
+	}
+	sk1, err := NewKllItemsSketch[string](8, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	assert.NoError(t, err)
+	sk2, err := NewKllItemsSketch[string](8, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	assert.NoError(t, err)
+	n := 26 //don't change this
+	for i := 1; i <= n; i++ {
+		j := rand.Intn(n) + 1
+		sk1.Update(intToFixedLengthString(j, 3))
+		sk2.Update(intToFixedLengthString(j+100, 3))
+	}
+	sk1.Merge(sk2)
+	//println(sk1.String(true, true)) //L1 and above should be sorted in reverse. Ignore L0.
+	lvl1size := sk1.levels[2] - sk1.levels[1]
+	itr := sk1.GetIterator()
+	itr.Next()
+	prev, _ := strconv.Atoi(strings.TrimSpace(itr.GetQuantile()))
+	for i := uint32(1); i < lvl1size; i++ {
+		if itr.Next() {
+			v, _ := strconv.Atoi(strings.TrimSpace(itr.GetQuantile()))
+			assert.True(t, v <= prev)
+			prev = v
 		}
 	}
 }

--- a/kll/items_sketch_test.go
+++ b/kll/items_sketch_test.go
@@ -35,18 +35,18 @@ const (
 )
 
 func TestItemsSketch_KLimits(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	_, err := NewKllItemsSketch[string](_MIN_K, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	_, err := NewKllItemsSketch[string](_MIN_K, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	_, err = NewKllItemsSketch[string](uint16(_MAX_K), _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	_, err = NewKllItemsSketch[string](uint16(_MAX_K), _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	_, err = NewKllItemsSketch[string](_MIN_K-1, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	_, err = NewKllItemsSketch[string](_MIN_K-1, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.Error(t, err)
 }
 
 func TestItemsSketch_Empty(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch, err := NewKllItemsSketch[string](200, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch, err := NewKllItemsSketch[string](200, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	assert.True(t, sketch.IsEmpty())
 	assert.False(t, sketch.IsEstimationMode())
@@ -68,8 +68,8 @@ func TestItemsSketch_Empty(t *testing.T) {
 }
 
 func TestItemsSketch_BadQuantile(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch, err := NewKllItemsSketch[string](200, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch, err := NewKllItemsSketch[string](200, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sketch.Update("") // has to be non-empty to reach the check
 	_, err = sketch.GetQuantile(-1, true)
@@ -77,8 +77,8 @@ func TestItemsSketch_BadQuantile(t *testing.T) {
 }
 
 func TestItemsSketch_OneValue(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch, err := NewKllItemsSketch[string](200, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch, err := NewKllItemsSketch[string](200, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sketch.Update("A")
 	assert.False(t, sketch.IsEmpty())
@@ -107,9 +107,9 @@ func TestItemsSketch_OneValue(t *testing.T) {
 }
 
 func TestItemsSketch_TenValues(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
+	comparator := common.ItemSketchStringComparator(false)
 	tenStr := []string{"A", "B", "C", "D", "E", "F", "G", "H", "I", "J"}
-	sketch, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	sketch, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	strLen := len(tenStr)
 	dblStrLen := float64(strLen)
@@ -184,8 +184,8 @@ func TestItemsSketch_TenValues(t *testing.T) {
 }
 
 func TestItemsSketch_ManyValuesEstimationMode(T *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch, err := NewKllItemsSketchWithDefault[string](comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(T, err)
 	n := 1_000_000
 	digits := numDigits(n)
@@ -245,8 +245,8 @@ func TestItemsSketch_ManyValuesEstimationMode(T *testing.T) {
 }
 
 func TestItemsSketch_GetRankGetCdfGetPmfConsistency(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch, err := NewKllItemsSketchWithDefault[string](comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 1000
 	digits := numDigits(n)
@@ -293,10 +293,10 @@ func TestItemsSketch_GetRankGetCdfGetPmfConsistency(t *testing.T) {
 }
 
 func TestItemsSketch_Merge(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch1, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch1, err := NewKllItemsSketchWithDefault[string](comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	sketch2, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	sketch2, err := NewKllItemsSketchWithDefault[string](comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 10000
 	digits := numDigits(2 * n)
@@ -337,10 +337,10 @@ func TestItemsSketch_Merge(t *testing.T) {
 }
 
 func TestItemsSketch_MergeLowerK(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch1, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch1, err := NewKllItemsSketchWithDefault[string](comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	sketch2, err := NewKllItemsSketch[string](_DEFAULT_K/2, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	sketch2, err := NewKllItemsSketch[string](_DEFAULT_K/2, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 10000
 	digits := numDigits(2 * n)
@@ -386,10 +386,10 @@ func TestItemsSketch_MergeLowerK(t *testing.T) {
 }
 
 func TestItemsSketch_MergeEmptyLowerK(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch1, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch1, err := NewKllItemsSketchWithDefault[string](comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	sketch2, err := NewKllItemsSketch[string](_DEFAULT_K/2, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	sketch2, err := NewKllItemsSketch[string](_DEFAULT_K/2, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 10000
 	digits := numDigits(n)
@@ -448,10 +448,10 @@ func TestItemsSketch_MergeEmptyLowerK(t *testing.T) {
 }
 
 func TestItemsSketch_MergeExactModeLowerK(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch1, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch1, err := NewKllItemsSketchWithDefault[string](comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	sketch2, err := NewKllItemsSketch[string](_DEFAULT_K/2, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	sketch2, err := NewKllItemsSketch[string](_DEFAULT_K/2, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 10000
 	digits := numDigits(n)
@@ -467,10 +467,10 @@ func TestItemsSketch_MergeExactModeLowerK(t *testing.T) {
 }
 
 func TestItemsSketch_MergeMinMinValueFromOther(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch1, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch1, err := NewKllItemsSketchWithDefault[string](comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	sketch2, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	sketch2, err := NewKllItemsSketchWithDefault[string](comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sketch1.Update(intToFixedLengthString(1, 1))
 	sketch2.Update(intToFixedLengthString(2, 1))
@@ -481,10 +481,10 @@ func TestItemsSketch_MergeMinMinValueFromOther(t *testing.T) {
 }
 
 func TestItemsSketch_MergeMinAndMaxFromOther(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch1, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch1, err := NewKllItemsSketchWithDefault[string](comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	sketch2, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	sketch2, err := NewKllItemsSketchWithDefault[string](comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 1_000_000
 	digits := numDigits(n)
@@ -501,14 +501,14 @@ func TestItemsSketch_MergeMinAndMaxFromOther(t *testing.T) {
 }
 
 func TestItemsSketch_KTooSmall(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	_, err := NewKllItemsSketch[string](_MIN_K-1, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	_, err := NewKllItemsSketch[string](_MIN_K-1, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.Error(t, err)
 }
 
 func TestItemsSketch_MinK(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch, err := NewKllItemsSketch[string](uint16(8), _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch, err := NewKllItemsSketch[string](uint16(8), _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 1000
 	digits := numDigits(n)
@@ -525,8 +525,8 @@ func TestItemsSketch_MinK(t *testing.T) {
 }
 
 func TestItemsSketch_MaxK(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch, err := NewKllItemsSketch[string](uint16(_MAX_K), _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch, err := NewKllItemsSketch[string](uint16(_MAX_K), _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 1000
 	digits := numDigits(n)
@@ -543,8 +543,8 @@ func TestItemsSketch_MaxK(t *testing.T) {
 }
 
 func TestItemsSketch_OutOfOrderSplitPoints(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch, err := NewKllItemsSketchWithDefault[string](comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	s0 := intToFixedLengthString(0, 1)
 	s1 := intToFixedLengthString(1, 1)
@@ -554,8 +554,8 @@ func TestItemsSketch_OutOfOrderSplitPoints(t *testing.T) {
 }
 
 func TestItemsSketch_DuplicateSplitPoints(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch, err := NewKllItemsSketchWithDefault[string](comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sketch.Update("A")
 	sketch.Update("B")
@@ -570,8 +570,8 @@ func TestItemsSketch_DuplicateSplitPoints(t *testing.T) {
 }
 
 func TestItemsSketch_CheckReset(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 100
 	digits := numDigits(n)
@@ -598,8 +598,8 @@ func TestItemsSketch_CheckReset(t *testing.T) {
 }
 
 func TestItemsSketch_SortedView(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sketch, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sketch.Update("A")
 	sketch.Update("AB")
@@ -627,13 +627,13 @@ func TestItemsSketch_SortedView(t *testing.T) {
 }
 
 func TestItemsSketch_CDF_PDF(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
+	comparator := common.ItemSketchStringComparator(false)
 	cdfI := []float64{.25, .50, .75, 1.0, 1.0}
 	cdfE := []float64{0.0, .25, .50, .75, 1.0}
 	pmfI := []float64{.25, .25, .25, .25, 0.0}
 	pmfE := []float64{0.0, .25, .25, .25, .25}
 	toll := 1e-10
-	sketch, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	sketch, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	strIn := []string{"A", "AB", "ABC", "ABCD"}
 	for i := 0; i < len(strIn); i++ {
@@ -670,8 +670,8 @@ func TestItemsSketch_CDF_PDF(t *testing.T) {
 }
 
 func TestItemsSketch_DeserializeEmpty(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	mem, err := sk1.ToSlice()
 	assert.NoError(t, err)
@@ -681,7 +681,7 @@ func TestItemsSketch_DeserializeEmpty(t *testing.T) {
 	assert.Equal(t, memVal.sketchStructure, _COMPACT_EMPTY)
 	assert.Equal(t, len(mem), 8)
 
-	sk2, err := NewKllItemsSketchFromSlice[string](mem, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	sk2, err := NewKllItemsSketchFromSlice[string](mem, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	assert.Equal(t, sk2.GetN(), uint64(0))
 	_, err = sk2.GetMinItem()
@@ -691,8 +691,8 @@ func TestItemsSketch_DeserializeEmpty(t *testing.T) {
 }
 
 func TestItemsSketch_DeserializeSingleItem(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sk1.Update("A")
 	mem, err := sk1.ToSlice()
@@ -701,7 +701,7 @@ func TestItemsSketch_DeserializeSingleItem(t *testing.T) {
 	memVal, err := newItemsSketchMemoryValidate[string](mem, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	assert.Equal(t, memVal.sketchStructure, _COMPACT_SINGLE)
-	sk2, err := NewKllItemsSketchFromSlice[string](mem, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	sk2, err := NewKllItemsSketchFromSlice[string](mem, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	assert.Equal(t, sk2.GetN(), uint64(1))
 	minV, err := sk2.GetMinItem()
@@ -713,8 +713,8 @@ func TestItemsSketch_DeserializeSingleItem(t *testing.T) {
 }
 
 func TestItemsSketch_FewItems(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sk1.Update("A")
 	sk1.Update("AB")
@@ -729,8 +729,8 @@ func TestItemsSketch_FewItems(t *testing.T) {
 }
 
 func TestItemsSketch_ManyItems(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 109
 	digits := numDigits(n)
@@ -747,8 +747,8 @@ func TestItemsSketch_ManyItems(t *testing.T) {
 }
 
 func TestItemsSketch_SortedViewAfterReset(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sk, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sk, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sk.Update("1")
 	sv, err := sk.GetSortedView()
@@ -762,13 +762,13 @@ func TestItemsSketch_SortedViewAfterReset(t *testing.T) {
 }
 
 func TestItemsSketch_SerializeDeserializeEmpty(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	mem, err := sk1.ToSlice()
 	assert.NoError(t, err)
 	assert.NotNil(t, mem)
-	sk2, err := NewKllItemsSketchFromSlice[string](mem, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	sk2, err := NewKllItemsSketchFromSlice[string](mem, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	s, err := sk1.GetSerializedSizeBytes()
 	assert.NoError(t, err)
@@ -792,14 +792,14 @@ func TestItemsSketch_SerializeDeserializeEmpty(t *testing.T) {
 }
 
 func TestItemsSketch_SerializeDeserializeOneValue(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sk1, err := NewKllItemsSketch[string](20, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	sk1.Update(" 1")
 	mem, err := sk1.ToSlice()
 	assert.NoError(t, err)
 	assert.NotNil(t, mem)
-	sk2, err := NewKllItemsSketchFromSlice[string](mem, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	sk2, err := NewKllItemsSketchFromSlice[string](mem, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	s1SizeBytes, err := sk1.GetSerializedSizeBytes()
 	assert.Equal(t, len(mem), s1SizeBytes)
@@ -824,8 +824,8 @@ func TestItemsSketch_SerializeDeserializeOneValue(t *testing.T) {
 }
 
 func TestItemsSketch_SerializeDeserializeMultipleValue(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sk1, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(false)
+	sk1, err := NewKllItemsSketchWithDefault[string](comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 1000
 	for i := 0; i < n; i++ {
@@ -840,7 +840,7 @@ func TestItemsSketch_SerializeDeserializeMultipleValue(t *testing.T) {
 	mem, err := sk1.ToSlice()
 	assert.NoError(t, err)
 	assert.NotNil(t, mem)
-	sk2, err := NewKllItemsSketchFromSlice[string](mem, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	sk2, err := NewKllItemsSketchFromSlice[string](mem, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	s1, err := sk2.GetSerializedSizeBytes()
 	assert.NoError(t, err)
@@ -864,10 +864,10 @@ func TestItemsSketch_SerializeDeserializeMultipleValue(t *testing.T) {
 
 func TestSerializeDeserializeString(t *testing.T) {
 	nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
-	comparator := common.ItemSketchStringComparator{}
+	comparator := common.ItemSketchStringComparator(false)
 	for _, n := range nArr {
 		digits := numDigits(n)
-		sk, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), common.ItemSketchStringSerDe{})
+		sk, err := NewKllItemsSketchWithDefault[string](comparator, common.ItemSketchStringSerDe{})
 		assert.NoError(t, err)
 		for i := 1; i <= n; i++ {
 			sk.Update(intToFixedLengthString(i, digits))
@@ -875,7 +875,7 @@ func TestSerializeDeserializeString(t *testing.T) {
 		slc, err := sk.ToSlice()
 		assert.NoError(t, err)
 
-		sketch, err := NewKllItemsSketchFromSlice[string](slc, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+		sketch, err := NewKllItemsSketchFromSlice[string](slc, comparator, common.ItemSketchStringSerDe{})
 		if err != nil {
 			return
 		}
@@ -904,7 +904,7 @@ func TestSerializeDeserializeString(t *testing.T) {
 
 			weight := int64(0)
 			it := sketch.GetIterator()
-			compareFn := comparator.CompareFn()
+			compareFn := comparator
 			for it.Next() {
 				qut := it.GetQuantile()
 				assert.True(t, compareFn(minV, qut) || minV == qut, fmt.Sprintf("min: \"%v\" \"%v\"", minV, qut))
@@ -918,9 +918,9 @@ func TestSerializeDeserializeString(t *testing.T) {
 
 func TestSerializeDeserializeFloat(t *testing.T) {
 	nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
-	comparator := common.ItemSketchDoubleComparator{}
+	comparator := common.ItemSketchDoubleComparator(false)
 	for _, n := range nArr {
-		sk, err := NewKllItemsSketchWithDefault[float64](comparator.CompareFn(), common.ItemSketchDoubleSerDe{})
+		sk, err := NewKllItemsSketchWithDefault[float64](comparator, common.ItemSketchDoubleSerDe{})
 		assert.NoError(t, err)
 		for i := 1; i <= n; i++ {
 			sk.Update(float64(i))
@@ -928,7 +928,7 @@ func TestSerializeDeserializeFloat(t *testing.T) {
 		slc, err := sk.ToSlice()
 		assert.NoError(t, err)
 
-		sketch, err := NewKllItemsSketchFromSlice[float64](slc, comparator.CompareFn(), common.ItemSketchDoubleSerDe{})
+		sketch, err := NewKllItemsSketchFromSlice[float64](slc, comparator, common.ItemSketchDoubleSerDe{})
 		if err != nil {
 			return
 		}
@@ -957,7 +957,7 @@ func TestSerializeDeserializeFloat(t *testing.T) {
 
 			weight := int64(0)
 			it := sketch.GetIterator()
-			compareFn := comparator.CompareFn()
+			compareFn := comparator
 			for it.Next() {
 				qut := it.GetQuantile()
 				assert.True(t, compareFn(minV, qut) || minV == qut, fmt.Sprintf("min: \"%v\" \"%v\"", minV, qut))
@@ -970,13 +970,13 @@ func TestSerializeDeserializeFloat(t *testing.T) {
 }
 
 func TestSerializeStringDeserializeNoSerde(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{}
-	sketch1, err := NewKllItemsSketchWithDefault[string](comparator.CompareFn(), nil)
+	comparator := common.ItemSketchStringComparator(false)
+	sketch1, err := NewKllItemsSketchWithDefault[string](comparator, nil)
 	assert.NoError(t, err)
 	_, err = sketch1.ToSlice()
 	assert.Error(t, err)
 
-	_, err = NewKllItemsSketchFromSlice[string](nil, comparator.CompareFn(), nil)
+	_, err = NewKllItemsSketchFromSlice[string](nil, comparator, nil)
 	assert.Error(t, err)
 }
 
@@ -989,12 +989,10 @@ func TestNoCompare(t *testing.T) {
 // The issue is, during a merge, L0 must be sorted prior to a compaction to a higher level.
 // Otherwise the higher levels would not be sorted properly.
 func TestL0SortDuringMerge(t *testing.T) {
-	comparator := common.ItemSketchStringComparator{
-		ReverseOrder: true,
-	}
-	sk1, err := NewKllItemsSketch[string](8, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	comparator := common.ItemSketchStringComparator(true)
+	sk1, err := NewKllItemsSketch[string](8, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
-	sk2, err := NewKllItemsSketch[string](8, _DEFAULT_M, comparator.CompareFn(), common.ItemSketchStringSerDe{})
+	sk2, err := NewKllItemsSketch[string](8, _DEFAULT_M, comparator, common.ItemSketchStringSerDe{})
 	assert.NoError(t, err)
 	n := 26 //don't change this
 	for i := 1; i <= n; i++ {

--- a/kll/items_sletch_serialization_test.go
+++ b/kll/items_sletch_serialization_test.go
@@ -34,9 +34,10 @@ func TestGenerateGoFiles(t *testing.T) {
 	os.Mkdir(internal.GoPath, 0755)
 
 	nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
+	comparatorString := common.ItemSketchStringComparator{}
 	for _, n := range nArr {
 		digits := numDigits(n)
-		sk, err := NewKllItemsSketchWithDefault[string](common.ArrayOfStringsSerDe{})
+		sk, err := NewKllItemsSketchWithDefault[string](comparatorString.CompareFn(), common.ItemSketchStringSerDe{})
 		sk.deterministicOffsetForTest = true
 		assert.NoError(t, err)
 		for i := 1; i <= n; i++ {
@@ -48,8 +49,9 @@ func TestGenerateGoFiles(t *testing.T) {
 		assert.NoError(t, err)
 	}
 
+	comparatorDouble := common.ItemSketchDoubleComparator{}
 	for _, n := range nArr {
-		sk, err := NewKllItemsSketchWithDefault[float64](common.ArrayOfDoublesSerDe{})
+		sk, err := NewKllItemsSketchWithDefault[float64](comparatorDouble.CompareFn(), common.ItemSketchDoubleSerDe{})
 		sk.deterministicOffsetForTest = true
 		assert.NoError(t, err)
 		for i := 1; i <= n; i++ {
@@ -65,12 +67,13 @@ func TestGenerateGoFiles(t *testing.T) {
 func TestJavaCompat(t *testing.T) {
 	t.Run("Java KLL String", func(t *testing.T) {
 		nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
-		serde := common.ArrayOfStringsSerDe{}
+		serde := common.ItemSketchStringSerDe{}
+		comparatorString := common.ItemSketchStringComparator{}
 		for _, n := range nArr {
 			digits := numDigits(n)
 			bytes, err := os.ReadFile(fmt.Sprintf("%s/kll_string_n%d_java.sk", internal.JavaPath, n))
 			assert.NoError(t, err)
-			sketch, err := NewKllItemsSketchFromSlice[string](bytes, serde)
+			sketch, err := NewKllItemsSketchFromSlice[string](bytes, comparatorString.CompareFn(), serde)
 			if err != nil {
 				return
 			}
@@ -99,11 +102,11 @@ func TestJavaCompat(t *testing.T) {
 
 				weight := int64(0)
 				it := sketch.GetIterator()
-				lessFn := serde.LessFn()
+				compareFn := comparatorString.CompareFn()
 				for it.Next() {
 					qut := it.GetQuantile()
-					assert.True(t, lessFn(minV, qut) || minV == qut, fmt.Sprintf("min: \"%v\" \"%v\"", minV, qut))
-					assert.True(t, !lessFn(maxV, qut) || maxV == qut, fmt.Sprintf("max: \"%v\" \"%v\"", maxV, qut))
+					assert.True(t, compareFn(minV, qut) || minV == qut, fmt.Sprintf("min: \"%v\" \"%v\"", minV, qut))
+					assert.True(t, !compareFn(maxV, qut) || maxV == qut, fmt.Sprintf("max: \"%v\" \"%v\"", maxV, qut))
 					weight += it.GetWeight()
 				}
 				assert.Equal(t, weight, int64(n))
@@ -113,11 +116,12 @@ func TestJavaCompat(t *testing.T) {
 
 	t.Run("Java KLL Double", func(t *testing.T) {
 		nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
-		serde := common.ArrayOfDoublesSerDe{}
+		serde := common.ItemSketchDoubleSerDe{}
+		comparatorDouble := common.ItemSketchDoubleComparator{}
 		for _, n := range nArr {
 			bytes, err := os.ReadFile(fmt.Sprintf("%s/kll_double_n%d_java.sk", internal.JavaPath, n))
 			assert.NoError(t, err)
-			sketch, err := NewKllItemsSketchFromSlice[float64](bytes, serde)
+			sketch, err := NewKllItemsSketchFromSlice[float64](bytes, comparatorDouble.CompareFn(), serde)
 			if err != nil {
 				return
 			}
@@ -146,11 +150,11 @@ func TestJavaCompat(t *testing.T) {
 
 				weight := int64(0)
 				it := sketch.GetIterator()
-				lessFn := serde.LessFn()
+				compareFn := comparatorDouble.CompareFn()
 				for it.Next() {
 					qut := it.GetQuantile()
-					assert.True(t, lessFn(minV, qut) || minV == qut, fmt.Sprintf("min: \"%v\" \"%v\"", minV, qut))
-					assert.True(t, !lessFn(maxV, qut) || maxV == qut, fmt.Sprintf("max: \"%v\" \"%v\"", maxV, qut))
+					assert.True(t, compareFn(minV, qut) || minV == qut, fmt.Sprintf("min: \"%v\" \"%v\"", minV, qut))
+					assert.True(t, !compareFn(maxV, qut) || maxV == qut, fmt.Sprintf("max: \"%v\" \"%v\"", maxV, qut))
 					weight += it.GetWeight()
 				}
 				assert.Equal(t, weight, int64(n))

--- a/kll/utils.go
+++ b/kll/utils.go
@@ -76,13 +76,13 @@ func checkNormalizedRankBounds(rank float64) error {
 	return nil
 }
 
-func checkItems[C comparable](items []C, lessFn common.LessFn[C]) error {
+func checkItems[C comparable](items []C, compareFn common.CompareFn[C]) error {
 	if len(items) == 1 && internal.IsNil(items[0]) {
 		return errors.New("items must be unique, monotonically increasing and not nil")
 	}
 
 	for i := 0; i < len(items)-1; i++ {
-		if !internal.IsNil(items[i]) && !internal.IsNil(items[i+1]) && lessFn(items[i], items[i+1]) {
+		if !internal.IsNil(items[i]) && !internal.IsNil(items[i+1]) && compareFn(items[i], items[i+1]) {
 			continue
 		}
 		return errors.New("items must be unique, monotonically increasing and not nil")

--- a/static-analysis.datadog.yml
+++ b/static-analysis.datadog.yml
@@ -1,0 +1,3 @@
+rulesets:
+  - go-best-practices
+  - go-security


### PR DESCRIPTION
Rework of https://github.com/apache/datasketches-go/pull/19

1. ItemSketch are now configured with one or more of ItemSketchSerde, ItemSketchComparator and ItemSketcherHasher depending of the need of the sketch.
Those arguments are optional when possible and methods relying on there implementation will return an error if used when badly configured.

2. Builtin comparator can now be configured for reverse ordering

3. Add the test covering the KLL lvl.0 sorting issue in https://github.com/apache/datasketches-java/pull/529 (note that the bug was not present here)

4. minor, removed Identity() from those interface, as this was only used to return a valid dummy value in case of errors, default initialiser for the type is now used