### PR TITLE
[Go] Optimise HLL union merge (HLLtoHLL)

### DIFF
--- a/hll/hll_sketch_test.go
+++ b/hll/hll_sketch_test.go
@@ -420,3 +420,18 @@ func TestHLL4RawStoredOldNibbleAndShiftedNewValueAuxToken(t *testing.T) {
 	err := hll.UpdateUInt64(29197004)
 	assert.NoError(t, err)
 }
+
+func BenchmarkHLLMerge(b *testing.B) {
+	hll1, err := NewHllSketch(11, TgtHllTypeHll8)
+	for i := uint64(0); i < 29197004; i++ {
+		err = hll1.UpdateUInt64(i)
+		assert.NoError(b, err)
+	}
+	u, _ := NewUnion(11)
+
+	b.Run("merge", func(b *testing.B) {
+		for i := 0; i < b.N; i++ {
+			u.UpdateSketch(hll1)
+		}
+	})
+}

--- a/hll/union.go
+++ b/hll/union.go
@@ -377,10 +377,10 @@ func mergeHlltoHLLmode(src HllSketch, tgt HllSketch, srcLgK int, tgtLgK int) err
 		{
 			srcArr := src.(*hllSketchState).sketch.(*hll8ArrayImpl).hllByteArr
 			tgtArr := tgt.(*hllSketchState).sketch.(*hll8ArrayImpl).hllByteArr
-			for i := 0; i < srcK; i++ {
-				srcV := srcArr[i]
-				tgtV := tgtArr[i]
-				tgtArr[i] = max(srcV, tgtV)
+			for i, srcV := range srcArr {
+				if srcV > tgtArr[i] {
+					tgtArr[i] = srcV
+				}
 			}
 		}
 	case 8, 9: //!HLL_8, srcLgK=tgtLgK, src=heap, tgt=heap/mem

--- a/hll/union.go
+++ b/hll/union.go
@@ -377,6 +377,8 @@ func mergeHlltoHLLmode(src HllSketch, tgt HllSketch, srcLgK int, tgtLgK int) err
 		{
 			srcArr := src.(*hllSketchState).sketch.(*hll8ArrayImpl).hllByteArr
 			tgtArr := tgt.(*hllSketchState).sketch.(*hll8ArrayImpl).hllByteArr
+			// Hack to trigger the bound check only once on tgtArr
+			tgtArr[len(srcArr)-1] = tgtArr[len(srcArr)-1]
 			for i, srcV := range srcArr {
 				if srcV > tgtArr[i] {
 					tgtArr[i] = srcV

--- a/hll/union.go
+++ b/hll/union.go
@@ -378,7 +378,7 @@ func mergeHlltoHLLmode(src HllSketch, tgt HllSketch, srcLgK int, tgtLgK int) err
 			srcArr := src.(*hllSketchState).sketch.(*hll8ArrayImpl).hllByteArr
 			tgtArr := tgt.(*hllSketchState).sketch.(*hll8ArrayImpl).hllByteArr
 			// Hack to trigger the bound check only once on tgtArr
-			tgtArr[len(srcArr)-1] = tgtArr[len(srcArr)-1]
+			_ = tgtArr[len(srcArr)-1]
 			for i, srcV := range srcArr {
 				if srcV > tgtArr[i] {
 					tgtArr[i] = srcV


### PR DESCRIPTION
```
goos: darwin
goarch: arm64
pkg: github.com/apache/datasketches-go/hll
                  │   old.txt    │              new-2.txt              │
                  │    sec/op    │   sec/op     vs base                │
HLLMerge/merge-10   1322.5n ± 1%   676.4n ± 0%  -48.85% (p=0.000 n=10)
```