### PR TITLE
[Go] Optimise HLL Update operation on arrays

### DIFF
--- a/hll/hll_4array.go
+++ b/hll/hll_4array.go
@@ -100,6 +100,7 @@ func newHll4Array(lgConfigK int) hllArray {
 			kxq1:        0,
 			hllByteArr:  make([]byte, 1<<(lgConfigK-1)),
 			auxStart:    hllByteArrStart + 1<<(lgConfigK-1),
+			configKMask: (1 << lgConfigK) - 1,
 		},
 	}
 }
@@ -176,8 +177,7 @@ func convertToHll4(srcAbsHllArr hllArray) (hllSketchStateI, error) {
 // couponUpdate updates the Hll4Array with the given coupon and returns the updated Hll4Array.
 func (h *hll4ArrayImpl) couponUpdate(coupon int) (hllSketchStateI, error) {
 	newValue := coupon >> keyBits26
-	configKmask := (1 << h.lgConfigK) - 1
-	slotNo := coupon & configKmask
+	slotNo := coupon & h.configKMask
 	err := internalHll4Update(h, slotNo, newValue)
 	return h, err
 }

--- a/hll/hll_4array.go
+++ b/hll/hll_4array.go
@@ -88,19 +88,14 @@ func (h *hll4ArrayImpl) copy() (hllSketchStateI, error) {
 func newHll4Array(lgConfigK int) hllArray {
 	return &hll4ArrayImpl{
 		hllArrayImpl: hllArrayImpl{
-			hllSketchConfig: hllSketchConfig{
-				lgConfigK:  lgConfigK,
-				tgtHllType: TgtHllTypeHll4,
-				curMode:    curModeHll,
-			},
-			curMin:      0,
-			numAtCurMin: 1 << lgConfigK,
-			hipAccum:    0,
-			kxq0:        float64(uint64(1 << lgConfigK)),
-			kxq1:        0,
-			hllByteArr:  make([]byte, 1<<(lgConfigK-1)),
-			auxStart:    hllByteArrStart + 1<<(lgConfigK-1),
-			configKMask: (1 << lgConfigK) - 1,
+			hllSketchConfig: newHllSketchConfig(lgConfigK, TgtHllTypeHll4, curModeHll),
+			curMin:          0,
+			numAtCurMin:     1 << lgConfigK,
+			hipAccum:        0,
+			kxq0:            float64(uint64(1 << lgConfigK)),
+			kxq1:            0,
+			hllByteArr:      make([]byte, 1<<(lgConfigK-1)),
+			auxStart:        hllByteArrStart + 1<<(lgConfigK-1),
 		},
 	}
 }
@@ -177,7 +172,7 @@ func convertToHll4(srcAbsHllArr hllArray) (hllSketchStateI, error) {
 // couponUpdate updates the Hll4Array with the given coupon and returns the updated Hll4Array.
 func (h *hll4ArrayImpl) couponUpdate(coupon int) (hllSketchStateI, error) {
 	newValue := coupon >> keyBits26
-	slotNo := coupon & h.configKMask
+	slotNo := coupon & h.slotNoMask
 	err := internalHll4Update(h, slotNo, newValue)
 	return h, err
 }

--- a/hll/hll_6array.go
+++ b/hll/hll_6array.go
@@ -82,6 +82,7 @@ func newHll6Array(lgConfigK int) hllArray {
 			kxq1:        0,
 			hllByteArr:  make([]byte, (((1<<lgConfigK)*3)>>2)+1),
 			auxStart:    hllByteArrStart + 1<<(lgConfigK-1),
+			configKMask: (1 << lgConfigK) - 1,
 		},
 	}
 }
@@ -96,8 +97,7 @@ func deserializeHll6(byteArray []byte) hllArray {
 
 func (h *hll6ArrayImpl) couponUpdate(coupon int) (hllSketchStateI, error) {
 	newValue := coupon >> keyBits26
-	configKmask := (1 << h.lgConfigK) - 1
-	slotNo := coupon & configKmask
+	slotNo := coupon & h.configKMask
 	err := h.updateSlotWithKxQ(slotNo, newValue)
 	return h, err
 }

--- a/hll/hll_6array.go
+++ b/hll/hll_6array.go
@@ -70,19 +70,14 @@ func (h *hll6ArrayImpl) ToUpdatableSlice() ([]byte, error) {
 func newHll6Array(lgConfigK int) hllArray {
 	return &hll6ArrayImpl{
 		hllArrayImpl: hllArrayImpl{
-			hllSketchConfig: hllSketchConfig{
-				lgConfigK:  lgConfigK,
-				tgtHllType: TgtHllTypeHll6,
-				curMode:    curModeHll,
-			},
-			curMin:      0,
-			numAtCurMin: 1 << lgConfigK,
-			hipAccum:    0,
-			kxq0:        float64(uint64(1 << lgConfigK)),
-			kxq1:        0,
-			hllByteArr:  make([]byte, (((1<<lgConfigK)*3)>>2)+1),
-			auxStart:    hllByteArrStart + 1<<(lgConfigK-1),
-			configKMask: (1 << lgConfigK) - 1,
+			hllSketchConfig: newHllSketchConfig(lgConfigK, TgtHllTypeHll6, curModeHll),
+			curMin:          0,
+			numAtCurMin:     1 << lgConfigK,
+			hipAccum:        0,
+			kxq0:            float64(uint64(1 << lgConfigK)),
+			kxq1:            0,
+			hllByteArr:      make([]byte, (((1<<lgConfigK)*3)>>2)+1),
+			auxStart:        hllByteArrStart + 1<<(lgConfigK-1),
 		},
 	}
 }
@@ -97,7 +92,7 @@ func deserializeHll6(byteArray []byte) hllArray {
 
 func (h *hll6ArrayImpl) couponUpdate(coupon int) (hllSketchStateI, error) {
 	newValue := coupon >> keyBits26
-	slotNo := coupon & h.configKMask
+	slotNo := coupon & h.slotNoMask
 	err := h.updateSlotWithKxQ(slotNo, newValue)
 	return h, err
 }

--- a/hll/hll_8array.go
+++ b/hll/hll_8array.go
@@ -24,7 +24,6 @@ import (
 // hll8ArrayImpl Uses 6 bits per slot in a packed byte array
 type hll8ArrayImpl struct {
 	hllArrayImpl
-	configKMask int
 }
 
 type hll8Iterator struct {
@@ -68,19 +67,14 @@ func (h *hll8ArrayImpl) ToUpdatableSlice() ([]byte, error) {
 func newHll8Array(lgConfigK int) hllArray {
 	return &hll8ArrayImpl{
 		hllArrayImpl: hllArrayImpl{
-			hllSketchConfig: hllSketchConfig{
-				lgConfigK:  lgConfigK,
-				tgtHllType: TgtHllTypeHll8,
-				curMode:    curModeHll,
-			},
-			curMin:      0,
-			numAtCurMin: 1 << lgConfigK,
-			hipAccum:    0,
-			kxq0:        float64(uint64(1 << lgConfigK)),
-			kxq1:        0,
-			hllByteArr:  make([]byte, 1<<lgConfigK),
-			auxStart:    hllByteArrStart + 1<<(lgConfigK-1),
-			configKMask: (1 << lgConfigK) - 1,
+			hllSketchConfig: newHllSketchConfig(lgConfigK, TgtHllTypeHll8, curModeHll),
+			curMin:          0,
+			numAtCurMin:     1 << lgConfigK,
+			hipAccum:        0,
+			kxq0:            float64(uint64(1 << lgConfigK)),
+			kxq1:            0,
+			hllByteArr:      make([]byte, 1<<lgConfigK),
+			auxStart:        hllByteArrStart + 1<<(lgConfigK-1),
 		},
 	}
 }
@@ -124,7 +118,7 @@ func convertToHll8(srcAbsHllArr hllArray) (hllSketchStateI, error) {
 
 func (h *hll8ArrayImpl) couponUpdate(coupon int) (hllSketchStateI, error) {
 	newValue := coupon >> keyBits26
-	slotNo := coupon & h.configKMask
+	slotNo := coupon & h.slotNoMask
 	err := h.updateSlotWithKxQ(slotNo, newValue)
 	return h, err
 }

--- a/hll/hll_8array.go
+++ b/hll/hll_8array.go
@@ -24,6 +24,7 @@ import (
 // hll8ArrayImpl Uses 6 bits per slot in a packed byte array
 type hll8ArrayImpl struct {
 	hllArrayImpl
+	configKMask int
 }
 
 type hll8Iterator struct {
@@ -79,6 +80,7 @@ func newHll8Array(lgConfigK int) hllArray {
 			kxq1:        0,
 			hllByteArr:  make([]byte, 1<<lgConfigK),
 			auxStart:    hllByteArrStart + 1<<(lgConfigK-1),
+			configKMask: (1 << lgConfigK) - 1,
 		},
 	}
 }
@@ -122,8 +124,7 @@ func convertToHll8(srcAbsHllArr hllArray) (hllSketchStateI, error) {
 
 func (h *hll8ArrayImpl) couponUpdate(coupon int) (hllSketchStateI, error) {
 	newValue := coupon >> keyBits26
-	configKmask := (1 << h.lgConfigK) - 1
-	slotNo := coupon & configKmask
+	slotNo := coupon & h.configKMask
 	err := h.updateSlotWithKxQ(slotNo, newValue)
 	return h, err
 }

--- a/hll/hll_array.go
+++ b/hll/hll_array.go
@@ -63,8 +63,6 @@ type hllArrayImpl struct {
 
 	auxHashMap *auxHashMap
 	auxStart   int //used for direct HLL4
-
-	configKMask int // mask from lgConfigK
 }
 
 // newHllArray returns a new hllArray of the given lgConfigK and tgtHllType.

--- a/hll/hll_array.go
+++ b/hll/hll_array.go
@@ -63,6 +63,8 @@ type hllArrayImpl struct {
 
 	auxHashMap *auxHashMap
 	auxStart   int //used for direct HLL4
+
+	configKMask int // mask from lgConfigK
 }
 
 // newHllArray returns a new hllArray of the given lgConfigK and tgtHllType.

--- a/hll/hll_config.go
+++ b/hll/hll_config.go
@@ -21,6 +21,8 @@ type hllSketchConfig struct { // extends hllSketchConfig
 	lgConfigK  int
 	tgtHllType TgtHllType
 	curMode    curMode
+
+	slotNoMask int // mask from lgConfigK to extract slotNo
 }
 
 func newHllSketchConfig(lgConfigK int, tgtHllType TgtHllType, curMode curMode) hllSketchConfig {
@@ -28,6 +30,7 @@ func newHllSketchConfig(lgConfigK int, tgtHllType TgtHllType, curMode curMode) h
 		lgConfigK:  lgConfigK,
 		tgtHllType: tgtHllType,
 		curMode:    curMode,
+		slotNoMask: (1 << lgConfigK) - 1,
 	}
 }
 

--- a/hll/hll_sketch_test.go
+++ b/hll/hll_sketch_test.go
@@ -244,61 +244,81 @@ func TestHLLDataSketchT(b *testing.T) {
 }
 
 func BenchmarkHLLDataSketch(b *testing.B) {
+	const iter = 2_000_000
+
 	// HLL uint64 BenchMark
 	b.Run("lgK4 HLL4 uint", func(b *testing.B) {
 		hll, _ := NewHllSketch(4, TgtHllTypeHll4)
 		for i := 0; i < b.N; i++ {
-			_ = hll.UpdateUInt64(uint64(i))
+			for j := 0; j < iter; j++ {
+				_ = hll.UpdateUInt64(uint64(j))
+			}
 		}
 	})
 	b.Run("lgK16 HLL4 uint", func(b *testing.B) {
 		hll, _ := NewHllSketch(16, TgtHllTypeHll4)
 		for i := 0; i < b.N; i++ {
-			_ = hll.UpdateUInt64(uint64(i))
+			for j := 0; j < iter; j++ {
+				_ = hll.UpdateUInt64(uint64(j))
+			}
 		}
 	})
 	b.Run("lgK21 HLL4 uint", func(b *testing.B) {
 		hll, _ := NewHllSketch(21, TgtHllTypeHll4)
 		for i := 0; i < b.N; i++ {
-			_ = hll.UpdateUInt64(uint64(i))
+			for j := 0; j < iter; j++ {
+				_ = hll.UpdateUInt64(uint64(j))
+			}
 		}
 	})
 
 	b.Run("lgK4 HLL6 uint", func(b *testing.B) {
 		hll, _ := NewHllSketch(11, TgtHllTypeHll6)
 		for i := 0; i < b.N; i++ {
-			_ = hll.UpdateUInt64(uint64(i))
+			for j := 0; j < iter; j++ {
+				_ = hll.UpdateUInt64(uint64(j))
+			}
 		}
 	})
 	b.Run("lgK16 HLL6 uint", func(b *testing.B) {
 		hll, _ := NewHllSketch(16, TgtHllTypeHll6)
 		for i := 0; i < b.N; i++ {
-			_ = hll.UpdateUInt64(uint64(i))
+			for j := 0; j < iter; j++ {
+				_ = hll.UpdateUInt64(uint64(j))
+			}
 		}
 	})
 	b.Run("lgK21 HLL6 uint", func(b *testing.B) {
 		hll, _ := NewHllSketch(21, TgtHllTypeHll6)
 		for i := 0; i < b.N; i++ {
-			_ = hll.UpdateUInt64(uint64(i))
+			for j := 0; j < iter; j++ {
+				_ = hll.UpdateUInt64(uint64(j))
+			}
 		}
 	})
 
 	b.Run("lgK4 HLL8 uint", func(b *testing.B) {
 		hll, _ := NewHllSketch(11, TgtHllTypeHll8)
 		for i := 0; i < b.N; i++ {
-			_ = hll.UpdateUInt64(uint64(i))
+			for j := 0; j < iter; j++ {
+				_ = hll.UpdateUInt64(uint64(j))
+			}
 		}
 	})
 	b.Run("lgK16 HLL8 uint", func(b *testing.B) {
 		hll, _ := NewHllSketch(16, TgtHllTypeHll8)
 		for i := 0; i < b.N; i++ {
-			_ = hll.UpdateUInt64(uint64(i))
+			for j := 0; j < iter; j++ {
+				_ = hll.UpdateUInt64(uint64(j))
+			}
 		}
 	})
 	b.Run("lgK21 HLL8 uint", func(b *testing.B) {
 		hll, _ := NewHllSketch(21, TgtHllTypeHll8)
 		for i := 0; i < b.N; i++ {
-			_ = hll.UpdateUInt64(uint64(i))
+			for j := 0; j < iter; j++ {
+				_ = hll.UpdateUInt64(uint64(j))
+			}
 		}
 	})
 
@@ -307,66 +327,84 @@ func BenchmarkHLLDataSketch(b *testing.B) {
 	b.Run("lgK4 HLL4 slice", func(b *testing.B) {
 		hll, _ := NewHllSketch(11, TgtHllTypeHll4)
 		for i := 0; i < b.N; i++ {
-			binary.LittleEndian.PutUint64(bs, uint64(i))
-			_ = hll.UpdateSlice(bs)
+			for j := 0; j < iter; j++ {
+				binary.LittleEndian.PutUint64(bs, uint64(j))
+				_ = hll.UpdateSlice(bs)
+			}
 		}
 	})
 	b.Run("lgK16 HLL4 slice", func(b *testing.B) {
 		hll, _ := NewHllSketch(16, TgtHllTypeHll4)
 		for i := 0; i < b.N; i++ {
-			binary.LittleEndian.PutUint64(bs, uint64(i))
-			_ = hll.UpdateSlice(bs)
+			for j := 0; j < iter; j++ {
+				binary.LittleEndian.PutUint64(bs, uint64(j))
+				_ = hll.UpdateSlice(bs)
+			}
 		}
 	})
 	b.Run("lgK21 HLL4 slice", func(b *testing.B) {
 		hll, _ := NewHllSketch(21, TgtHllTypeHll4)
 		for i := 0; i < b.N; i++ {
-			binary.LittleEndian.PutUint64(bs, uint64(i))
-			_ = hll.UpdateSlice(bs)
+			for j := 0; j < iter; j++ {
+				binary.LittleEndian.PutUint64(bs, uint64(j))
+				_ = hll.UpdateSlice(bs)
+			}
 		}
 	})
 
 	b.Run("lgK4 HLL6 slice", func(b *testing.B) {
 		hll, _ := NewHllSketch(11, TgtHllTypeHll6)
 		for i := 0; i < b.N; i++ {
-			binary.LittleEndian.PutUint64(bs, uint64(i))
-			_ = hll.UpdateSlice(bs)
+			for j := 0; j < iter; j++ {
+				binary.LittleEndian.PutUint64(bs, uint64(j))
+				_ = hll.UpdateSlice(bs)
+			}
 		}
 	})
 	b.Run("lgK16 HLL6 slice", func(b *testing.B) {
 		hll, _ := NewHllSketch(16, TgtHllTypeHll6)
 		for i := 0; i < b.N; i++ {
-			binary.LittleEndian.PutUint64(bs, uint64(i))
-			_ = hll.UpdateSlice(bs)
+			for j := 0; j < iter; j++ {
+				binary.LittleEndian.PutUint64(bs, uint64(j))
+				_ = hll.UpdateSlice(bs)
+			}
 		}
 	})
 	b.Run("lgK21 HLL6 slice", func(b *testing.B) {
 		hll, _ := NewHllSketch(21, TgtHllTypeHll6)
 		for i := 0; i < b.N; i++ {
-			binary.LittleEndian.PutUint64(bs, uint64(i))
-			_ = hll.UpdateSlice(bs)
+			for j := 0; j < iter; j++ {
+				binary.LittleEndian.PutUint64(bs, uint64(j))
+				_ = hll.UpdateSlice(bs)
+			}
 		}
 	})
 
 	b.Run("lgK4 HLL8 slice", func(b *testing.B) {
 		hll, _ := NewHllSketch(11, TgtHllTypeHll8)
 		for i := 0; i < b.N; i++ {
-			binary.LittleEndian.PutUint64(bs, uint64(i))
-			_ = hll.UpdateSlice(bs)
+			for j := 0; j < iter; j++ {
+				binary.LittleEndian.PutUint64(bs, uint64(j))
+				_ = hll.UpdateSlice(bs)
+			}
 		}
 	})
 	b.Run("lgK16 HLL8 slice", func(b *testing.B) {
 		hll, _ := NewHllSketch(16, TgtHllTypeHll8)
 		for i := 0; i < b.N; i++ {
-			binary.LittleEndian.PutUint64(bs, uint64(i))
-			_ = hll.UpdateSlice(bs)
+			for j := 0; j < iter; j++ {
+				binary.LittleEndian.PutUint64(bs, uint64(j))
+				_ = hll.UpdateSlice(bs)
+			}
 		}
 	})
 	b.Run("lgK21 HLL8 slice", func(b *testing.B) {
 		hll, _ := NewHllSketch(21, TgtHllTypeHll8)
 		for i := 0; i < b.N; i++ {
-			binary.LittleEndian.PutUint64(bs, uint64(i))
-			_ = hll.UpdateSlice(bs)
+			for j := 0; j < iter; j++ {
+				binary.LittleEndian.PutUint64(bs, uint64(j))
+				_ = hll.UpdateSlice(bs)
+			}
 		}
 	})
 


### PR DESCRIPTION
Precompute the slotMask once per HLL/config instead of per update

```
goos: darwin
goarch: arm64
pkg: github.com/apache/datasketches-go/hll
                                  │ old-all-bench.txt │         new-all-bench.txt          │
                                  │      sec/op       │   sec/op     vs base               │
HLLDataSketch/lgK4_HLL4_uint-10           18.67m ± 1%   18.07m ± 2%  -3.24% (p=0.002 n=12)
HLLDataSketch/lgK16_HLL4_uint-10          18.68m ± 1%   18.16m ± 1%  -2.81% (p=0.000 n=12)
HLLDataSketch/lgK21_HLL4_uint-10          20.35m ± 0%   20.00m ± 0%  -1.72% (p=0.000 n=12)
HLLDataSketch/lgK4_HLL6_uint-10           19.01m ± 1%   18.34m ± 1%  -3.52% (p=0.000 n=12)
HLLDataSketch/lgK16_HLL6_uint-10          19.24m ± 1%   18.38m ± 0%  -4.44% (p=0.000 n=12)
HLLDataSketch/lgK21_HLL6_uint-10          21.32m ± 1%   20.13m ± 1%  -5.59% (p=0.000 n=12)
HLLDataSketch/lgK4_HLL8_uint-10           17.19m ± 1%   16.83m ± 0%  -2.13% (p=0.000 n=12)
HLLDataSketch/lgK16_HLL8_uint-10          17.28m ± 0%   16.89m ± 0%  -2.25% (p=0.000 n=12)
HLLDataSketch/lgK21_HLL8_uint-10          18.68m ± 0%   18.32m ± 0%  -1.94% (p=0.002 n=12)
HLLDataSketch/lgK4_HLL4_slice-10          19.29m ± 0%   18.83m ± 0%  -2.39% (p=0.000 n=12)
HLLDataSketch/lgK16_HLL4_slice-10         19.50m ± 1%   18.89m ± 0%  -3.13% (p=0.000 n=12)
HLLDataSketch/lgK21_HLL4_slice-10         21.15m ± 1%   20.46m ± 0%  -3.27% (p=0.000 n=12)
HLLDataSketch/lgK4_HLL6_slice-10          19.71m ± 0%   19.15m ± 0%  -2.83% (p=0.000 n=12)
HLLDataSketch/lgK16_HLL6_slice-10         19.85m ± 1%   19.24m ± 0%  -3.07% (p=0.000 n=12)
HLLDataSketch/lgK21_HLL6_slice-10         21.14m ± 0%   20.58m ± 0%  -2.69% (p=0.000 n=12)
HLLDataSketch/lgK4_HLL8_slice-10          18.07m ± 0%   17.67m ± 0%  -2.21% (p=0.000 n=12)
HLLDataSketch/lgK16_HLL8_slice-10         18.14m ± 1%   17.74m ± 0%  -2.23% (p=0.000 n=12)
HLLDataSketch/lgK21_HLL8_slice-10         19.58m ± 1%   19.14m ± 1%  -2.23% (p=0.000 n=12)
HLLDataSketch/lgK4_HLL8_union-10          23.42n ± 0%   23.34n ± 1%  -0.36% (p=0.016 n=12)
HLLDataSketch/lgK16_HLL8_union-10         23.40n ± 0%   23.34n ± 0%  -0.26% (p=0.008 n=12)
HLLDataSketch/lgK21_HLL8_union-10         23.44n ± 1%   23.36n ± 0%  -0.32% (p=0.009 n=12)
geomean                                   2.749m        2.680m       -2.51%
```