### PR TITLE
Bump to Go 1.22

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.21.x' ]
+        go-version: [ '1.22.x' ]
     steps:
     - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ If you are interested in making contributions to this site please see our [Commu
 | 	            | CormodeItemsSketch<T>   | ❌ |
 | 	            | KllDoublesSketch        | ❌ |
 | 	            | KllFloatsSketch         | ❌ |
-| 	            | KllSketch<T>            | ❌ |
+| 	            | KllSketch<T>            | ⚠️ |
 | 	            | ReqFloatsSketch         | ❌ |
 | Frequencies  |              | ️ |
 |              | LongsSketch             | ⚠️ |
@@ -77,4 +77,4 @@ If you are interested in making contributions to this site please see our [Commu
 
 =================
 
-This code requires Go 1.21
+This code requires Go 1.22

--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,9 @@
 
 module github.com/apache/datasketches-go
 
-go 1.21
+go 1.22
 
-toolchain go1.21.1
+toolchain go1.22.5
 
 require (
 	github.com/stretchr/testify v1.8.4


### PR DESCRIPTION
Go 1.21 is reaching EOL, bumping to 1.22