### PR TITLE
Bump to go 1.23.5 and update Readme wrt CPC sketch progress

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go-version: [ '1.22.x' ]
+        go-version: [ '1.23.x' ]
     steps:
     - uses: actions/checkout@v3
 

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ If you are interested in making contributions to this site please see our [Commu
 | Type         | Implementation          | Status |
 |--------------|-------------------------|--|
 | Cardinality	 |                         |  |
-| 	            | CpcSketch               | ❌ |
+| 	            | CpcSketch               | 🚧 |
 | 	            | HllSketch               | ⚠️ |
 | 	            | ThetaSketch             | ❌ |
 | 	            | TupleSketch<S>          | ❌ |
@@ -75,6 +75,8 @@ If you are interested in making contributions to this site please see our [Commu
 
 ⚠️ = Implemented but not officially released
 
+🚧 = In progress
+
 =================
 
-This code requires Go 1.22
+This code requires Go 1.23

--- a/go.mod
+++ b/go.mod
@@ -17,9 +17,9 @@
 
 module github.com/apache/datasketches-go
 
-go 1.22
+go 1.23
 
-toolchain go1.22.5
+toolchain go1.23.5
 
 require (
 	github.com/stretchr/testify v1.8.4


### PR DESCRIPTION
Bump to latest Go (1.23) version as 1.22 is reaching EOL next month.

Update Readme to indicate WIP on CPCSketch
