### PR TITLE
Fix NewCpcUnionSketch seed argument

### DIFF
--- a/cpc/cpc_union.go
+++ b/cpc/cpc_union.go
@@ -37,7 +37,7 @@ type CpcUnion struct {
 }
 
 func NewCpcUnionSketch(lgK int, seed uint64) (CpcUnion, error) {
-	acc, err := NewCpcSketch(lgK, internal.DEFAULT_UPDATE_SEED)
+	acc, err := NewCpcSketch(lgK, seed)
 	if err != nil {
 		return CpcUnion{}, err
 	}


### PR DESCRIPTION
`NewCpcUnionSketch` was passing internal seed to `NewCpcSketch`  although it accepts a user provided seed in its parameters. So, that seed is also passed to `NewCpcSketch`