### PR TITLE
perf: use slices.sort

### DIFF
--- a/frequencies/items_sketch.go
+++ b/frequencies/items_sketch.go
@@ -29,11 +29,12 @@ import (
 	"encoding/binary"
 	"errors"
 	"fmt"
-	"github.com/apache/datasketches-go/common"
-	"github.com/apache/datasketches-go/internal"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
+
+	"github.com/apache/datasketches-go/common"
+	"github.com/apache/datasketches-go/internal"
 )
 
 type ItemsSketch[C comparable] struct {
@@ -515,8 +516,14 @@ func (i *ItemsSketch[C]) sortItems(threshold int64, errorType errorType) ([]*Row
 		}
 	}
 
-	sort.Slice(rowList, func(i, j int) bool {
-		return rowList[i].est > rowList[j].est
+	slices.SortFunc(rowList, func(a, b *RowItem[C]) int {
+		if a.est > b.est {
+			return -1
+		}
+		if a.est < b.est {
+			return 1
+		}
+		return 0
 	})
 
 	return rowList, nil

--- a/frequencies/longs_sketch.go
+++ b/frequencies/longs_sketch.go
@@ -22,7 +22,7 @@ import (
 	"errors"
 	"fmt"
 	"math/bits"
-	"sort"
+	"slices"
 	"strconv"
 	"strings"
 
@@ -598,8 +598,14 @@ func (s *LongsSketch) sortItems(threshold int64, errorType errorType) ([]*Row, e
 		}
 	}
 
-	sort.Slice(rowList, func(i, j int) bool {
-		return rowList[i].est > rowList[j].est
+	slices.SortFunc(rowList, func(a, b *Row) int {
+		if a.est > b.est {
+			return -1
+		}
+		if a.est < b.est {
+			return 1
+		}
+		return 0
 	})
 
 	return rowList, nil

--- a/kll/items_sketch.go
+++ b/kll/items_sketch.go
@@ -29,10 +29,11 @@ package kll
 import (
 	"encoding/binary"
 	"fmt"
+	"math/rand"
+	"slices"
+
 	"github.com/apache/datasketches-go/common"
 	"github.com/apache/datasketches-go/internal"
-	"math/rand"
-	"sort"
 )
 
 type ItemsSketch[C comparable] struct {
@@ -862,8 +863,11 @@ func (s *ItemsSketch[C]) compressWhileUpdatingSketch() {
 	myItemsArr := s.GetTotalItemsArray()
 	if level == 0 { // level zero might not be sorted, so we must sort it if we wish to compact it
 		tmpSlice := myItemsArr[adjBeg : adjBeg+adjPop]
-		sort.Slice(tmpSlice, func(a, b int) bool {
-			return s.compareFn(tmpSlice[a], tmpSlice[b])
+		slices.SortFunc(tmpSlice, func(a, b C) int {
+			if s.compareFn(a, b) {
+				return -1
+			}
+			return 1
 		})
 	}
 	if popAbove == 0 {
@@ -1154,8 +1158,11 @@ func generalItemsCompress[C comparable](
 			// level zero might not be sorted, so we must sort it if we wish to compact it
 			if (curLevel == 0) && !isLevelZeroSorted {
 				tmpSlice := inBuf[adjBeg : adjBeg+adjPop]
-				sort.Slice(tmpSlice, func(a, b int) bool {
-					return compareFn(tmpSlice[a], tmpSlice[b])
+				slices.SortFunc(tmpSlice, func(a, b C) int {
+					if compareFn(a, b) {
+						return -1
+					}
+					return 1
 				})
 			}
 


### PR DESCRIPTION
use slices.SortFunc. 

It is generally recommended in [Docs](https://pkg.go.dev/sort#Slice)

Benchmark:

``` 
# Sort Performance Comparison For "Row": sort.Slice vs slices.SortFunc

## Benchmark Results

goos: darwin
goarch: arm64
pkg: github.com/apache/datasketches-go/frequencies
cpu: Apple M1 Pro
BenchmarkSortSlice
BenchmarkSortSlice/size=10
BenchmarkSortSlice/size=10-10         	 7209180	       160.6 ns/op	     136 B/op	       3 allocs/op
BenchmarkSortSlice/size=100
BenchmarkSortSlice/size=100-10        	  574626	      2021 ns/op	     952 B/op	       3 allocs/op
BenchmarkSortSlice/size=1000
BenchmarkSortSlice/size=1000-10       	   27068	     43068 ns/op	    8248 B/op	       3 allocs/op
BenchmarkSortSlice/size=10000
BenchmarkSortSlice/size=10000-10      	    1363	    864653 ns/op	   81976 B/op	       3 allocs/op


goos: darwin
goarch: arm64
pkg: github.com/apache/datasketches-go/frequencies
cpu: Apple M1 Pro
BenchmarkSlicesSortFunc
BenchmarkSlicesSortFunc/size=10
BenchmarkSlicesSortFunc/size=10-10         	 9643902	       114.1 ns/op	      80 B/op	       1 allocs/op
BenchmarkSlicesSortFunc/size=100
BenchmarkSlicesSortFunc/size=100-10        	  667498	      1730 ns/op	     896 B/op	       1 allocs/op
BenchmarkSlicesSortFunc/size=1000
BenchmarkSlicesSortFunc/size=1000-10       	   27518	     41382 ns/op	    8192 B/op	       1 allocs/op
BenchmarkSlicesSortFunc/size=10000
BenchmarkSlicesSortFunc/size=10000-10      	    1582	    758889 ns/op	   81920 B/op	       1 allocs/op
```