### PR TITLE
feat: add update theta sketch

### DIFF
--- a/theta/update_sketch.go
+++ b/theta/update_sketch.go
@@ -1,0 +1,415 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package theta
+
+import (
+	"errors"
+	"fmt"
+	"iter"
+	"math"
+	"strings"
+
+	"github.com/apache/datasketches-go/internal"
+	"github.com/apache/datasketches-go/internal/binomialbounds"
+)
+
+var (
+	ErrUpdateEmptyString = errors.New("cannot update empty string")
+	ErrDuplicateKey      = errors.New("duplicate key")
+)
+
+// QuickSelectUpdateSketch is an Update Theta sketch based on the QuickSelect algorithm.
+// The purpose of this class is to build a Theta sketch from input data via the update() methods.
+type QuickSelectUpdateSketch struct {
+	table *Hashtable
+}
+
+type updateSketchOptions struct {
+	theta     uint64
+	seed      uint64
+	p         float32
+	lgCurSize uint8
+	lgK       uint8
+	rf        ResizeFactor
+}
+
+type UpdateSketchOptionFunc func(*updateSketchOptions)
+
+// WithUpdateSketchLgK sets log2(k), where k is a nominal number of entries in the sketch
+func WithUpdateSketchLgK(lgK uint8) UpdateSketchOptionFunc {
+	return func(opts *updateSketchOptions) {
+		opts.lgK = lgK
+	}
+}
+
+// WithUpdateSketchResizeFactor sets a resize factor for the internal hash table (defaults to 8)
+func WithUpdateSketchResizeFactor(rf ResizeFactor) UpdateSketchOptionFunc {
+	return func(opts *updateSketchOptions) {
+		opts.rf = rf
+	}
+}
+
+// WithUpdateSketchP sets sampling probability (initial theta). The default is 1, so the sketch retains
+// all entries until it reaches the limit, at which point it goes into the estimation mode
+// and reduces the effective sampling probability (theta) as necessary
+func WithUpdateSketchP(p float32) UpdateSketchOptionFunc {
+	return func(opts *updateSketchOptions) {
+		opts.p = p
+	}
+}
+
+// WithUpdateSketchSeed sets the seed for the hash function. Should be used carefully if needed.
+// Sketches produced with different seed are not compatible
+// and cannot be mixed in set operations.
+func WithUpdateSketchSeed(seed uint64) UpdateSketchOptionFunc {
+	return func(opts *updateSketchOptions) {
+		opts.seed = seed
+	}
+}
+
+// NewQuickSelectUpdateSketch creates a new quickselect update sketch with the given options
+func NewQuickSelectUpdateSketch(opts ...UpdateSketchOptionFunc) (*QuickSelectUpdateSketch, error) {
+	options := &updateSketchOptions{
+		lgK:  DefaultLgK,
+		rf:   DefaultResizeFactor,
+		p:    1.0,
+		seed: DefaultSeed,
+	}
+	for _, opt := range opts {
+		opt(options)
+	}
+
+	if options.lgK < MinLgK {
+		return nil, fmt.Errorf("lg_k must not be less than %d: %d", MinLgK, options.lgK)
+	}
+	if options.lgK > MaxLgK {
+		return nil, fmt.Errorf("lg_k must not be greater than %d: %d", MaxLgK, options.lgK)
+	}
+	if options.p <= 0 || options.p > 1 {
+		return nil, errors.New("sampling probability must be between 0 and 1")
+	}
+
+	options.lgCurSize = startingSubMultiple(options.lgK+1, MinLgK, uint8(options.rf))
+	options.theta = startingThetaFromP(options.p)
+
+	return &QuickSelectUpdateSketch{
+		table: NewHashtable(
+			options.lgCurSize, options.lgK, options.rf, options.p, options.theta, options.seed, true,
+		),
+	}, nil
+}
+
+// IsEmpty returns true if this sketch represents an empty set
+func (s *QuickSelectUpdateSketch) IsEmpty() bool {
+	return s.table.isEmpty
+}
+
+// IsOrdered returns true if retained entries are ordered
+func (s *QuickSelectUpdateSketch) IsOrdered() bool {
+	return s.table.numEntries <= 1
+}
+
+// Theta64 returns theta as a positive integer between 0 and math.MaxInt64
+func (s *QuickSelectUpdateSketch) Theta64() uint64 {
+	if s.IsEmpty() {
+		return MaxTheta
+	}
+	return s.table.theta
+}
+
+// NumRetained returns the number of retained entries in the sketch
+func (s *QuickSelectUpdateSketch) NumRetained() uint32 {
+	return s.table.numEntries
+}
+
+// SeedHash returns hash of the seed that was used to hash the input
+func (s *QuickSelectUpdateSketch) SeedHash() (uint16, error) {
+	seedHash, err := internal.ComputeSeedHash(int64(s.table.seed))
+	if err != nil {
+		return 0, err
+	}
+	return uint16(seedHash), nil
+}
+
+// Estimate returns estimate of the distinct count of the input stream
+func (s *QuickSelectUpdateSketch) Estimate() float64 {
+	return float64(s.NumRetained()) / s.Theta()
+}
+
+// LowerBound returns the approximate lower error bound given a number of standard deviations.
+// This parameter is similar to the number of standard deviations of the normal distribution
+// and corresponds to approximately 67%, 95% and 99% confidence intervals.
+// numStdDevs number of Standard Deviations (1, 2 or 3)
+func (s *QuickSelectUpdateSketch) LowerBound(numStdDevs uint8) (float64, error) {
+	if !s.IsEstimationMode() {
+		return float64(s.NumRetained()), nil
+	}
+	return binomialbounds.LowerBound(uint64(s.NumRetained()), s.Theta(), uint(numStdDevs))
+}
+
+// UpperBound returns the approximate upper error bound given a number of standard deviations.
+// This parameter is similar to the number of standard deviations of the normal distribution
+// and corresponds to approximately 67%, 95% and 99% confidence intervals.
+// numStdDevs number of Standard Deviations (1, 2 or 3)
+func (s *QuickSelectUpdateSketch) UpperBound(numStdDevs uint8) (float64, error) {
+	if !s.IsEstimationMode() {
+		return float64(s.NumRetained()), nil
+	}
+	return binomialbounds.UpperBound(uint64(s.NumRetained()), s.Theta(), uint(numStdDevs))
+}
+
+// IsEstimationMode returns true if the sketch is in estimation mode
+// (as opposed to exact mode)
+func (s *QuickSelectUpdateSketch) IsEstimationMode() bool {
+	return s.Theta64() < MaxTheta && !s.IsEmpty()
+}
+
+// Theta returns theta as a fraction from 0 to 1 (effective sampling rate)
+func (s *QuickSelectUpdateSketch) Theta() float64 {
+	return float64(s.Theta64()) / float64(MaxTheta)
+}
+
+// String returns a human-readable summary of this sketch as a string
+// If shouldPrintItems is true, include the list of items retained by the sketch
+func (s *QuickSelectUpdateSketch) String(shouldPrintItems bool) string {
+	seedHash, _ := s.SeedHash()
+	lb, _ := s.LowerBound(2)
+	ub, _ := s.UpperBound(2)
+
+	var result strings.Builder
+	result.WriteString("### Theta sketch summary:")
+	result.WriteString("\n")
+	result.WriteString(fmt.Sprintf("   num retained entries : %d", s.NumRetained()))
+	result.WriteString("\n")
+	result.WriteString(fmt.Sprintf("   seed hash            : %d", seedHash))
+	result.WriteString("\n")
+	result.WriteString(fmt.Sprintf("   empty?               : %t", s.IsEmpty()))
+	result.WriteString("\n")
+	result.WriteString(fmt.Sprintf("   ordered?             : %t", s.IsOrdered()))
+	result.WriteString("\n")
+	result.WriteString(fmt.Sprintf("   estimation mode?     : %t", s.IsEstimationMode()))
+	result.WriteString("\n")
+	result.WriteString(fmt.Sprintf("   theta (fraction)     : %f", s.Theta()))
+	result.WriteString("\n")
+	result.WriteString(fmt.Sprintf("   theta (raw 64-bit)   : %d", s.Theta64()))
+	result.WriteString("\n")
+	result.WriteString(fmt.Sprintf("   estimate             : %f", s.Estimate()))
+	result.WriteString("\n")
+	result.WriteString(fmt.Sprintf("   lower bound 95%% conf : %f", lb))
+	result.WriteString("\n")
+	result.WriteString(fmt.Sprintf("   upper bound 95%% conf : %f", ub))
+	result.WriteString("\n")
+	result.WriteString(fmt.Sprintf("   lg nominal size      : %d", s.LgK()))
+	result.WriteString("\n")
+	result.WriteString(fmt.Sprintf("   lg current size      : %d", s.table.lgCurSize))
+	result.WriteString("\n")
+	result.WriteString(fmt.Sprintf("   resize factor        : %d", 1<<s.ResizeFactor()))
+	result.WriteString("\n")
+	result.WriteString("### End sketch summary")
+	result.WriteString("\n")
+
+	if shouldPrintItems {
+		result.WriteString("### Retained entries")
+		result.WriteString("\n")
+
+		for hash := range s.All() {
+			result.WriteString(fmt.Sprintf("%d", hash))
+			result.WriteString("\n")
+		}
+
+		result.WriteString("### End retained entries")
+		result.WriteString("\n")
+	}
+
+	return result.String()
+}
+
+// LgK returns configured nominal number of entries in the sketch
+func (s *QuickSelectUpdateSketch) LgK() uint8 {
+	return s.table.lgNomSize
+}
+
+// ResizeFactor returns a configured resize factor of the sketch
+func (s *QuickSelectUpdateSketch) ResizeFactor() ResizeFactor {
+	return s.table.rf
+}
+
+// UpdateUint64 updates this sketch with a given unsigned 64-bit integer
+// Only update when the value is not existing
+func (s *QuickSelectUpdateSketch) UpdateUint64(value uint64) error {
+	return s.UpdateInt64(int64(value))
+}
+
+// UpdateInt64 updates this sketch with a given signed 64-bit integer
+// Only update when the value is not existing
+func (s *QuickSelectUpdateSketch) UpdateInt64(value int64) error {
+	hash, err := s.table.HashInt64AndScreen(value)
+	if err != nil {
+		return err
+	}
+
+	index, err := s.table.Find(hash)
+	if err != nil {
+		if errors.Is(err, ErrKeyNotFound) {
+			s.table.Insert(index, hash)
+			return nil
+		}
+		return err
+	}
+
+	return ErrDuplicateKey
+}
+
+// UpdateUint32 updates this sketch with a given unsigned 32-bit integer
+// Only update when the value is not existing
+func (s *QuickSelectUpdateSketch) UpdateUint32(value uint32) error {
+	return s.UpdateInt64(int64(value))
+}
+
+// UpdateInt32 updates this sketch with a given signed 32-bit integer
+// Only update when the value is not existing
+func (s *QuickSelectUpdateSketch) UpdateInt32(value int32) error {
+	hash, err := s.table.HashInt32AndScreen(value)
+	if err != nil {
+		return err
+	}
+
+	index, err := s.table.Find(hash)
+	if err != nil {
+		if errors.Is(err, ErrKeyNotFound) {
+			s.table.Insert(index, hash)
+			return nil
+		}
+		return err
+	}
+
+	return ErrDuplicateKey
+}
+
+// UpdateUint16 updates this sketch with a given unsigned 16-bit integer
+// Only update when the value is not existing
+func (s *QuickSelectUpdateSketch) UpdateUint16(value uint16) error {
+	return s.UpdateInt32(int32(value))
+}
+
+// UpdateInt16 updates this sketch with a given signed 16-bit integer
+// Only update when the value is not existing
+func (s *QuickSelectUpdateSketch) UpdateInt16(value int16) error {
+	return s.UpdateInt32(int32(value))
+}
+
+// UpdateUint8 updates this sketch with a given unsigned 8-bit integer
+// Only update when the value is not existing
+func (s *QuickSelectUpdateSketch) UpdateUint8(value uint8) error {
+	return s.UpdateInt32(int32(value))
+}
+
+// UpdateInt8 updates this sketch with a given signed 8-bit integer
+// Only update when the value is not existing
+func (s *QuickSelectUpdateSketch) UpdateInt8(value int8) error {
+	return s.UpdateInt32(int32(value))
+}
+
+// UpdateFloat64 updates this sketch with a given double-precision floating point value
+// Only update when the value is not existing
+func (s *QuickSelectUpdateSketch) UpdateFloat64(value float64) error {
+	return s.UpdateInt64(canonicalDouble(value))
+}
+
+// canonicalDouble canonicalizes double values for Java compatibility
+func canonicalDouble(value float64) int64 {
+	if value == 0.0 {
+		value = 0.0 // canonicalize -0.0 to 0.0
+	} else if math.IsNaN(value) {
+		return 0x7ff8000000000000 // canonicalize NaN using value from Java's Double.doubleToLongBits()
+	}
+	return int64(math.Float64bits(value))
+}
+
+// UpdateFloat32 updates this sketch with a given floating point value
+// Only update when the value is not existing
+func (s *QuickSelectUpdateSketch) UpdateFloat32(value float32) error {
+	return s.UpdateFloat64(float64(value))
+}
+
+// UpdateString updates this sketch with a given string
+// Only update when the value is not existing
+func (s *QuickSelectUpdateSketch) UpdateString(value string) error {
+	if value == "" {
+		return ErrUpdateEmptyString
+	}
+
+	hash, err := s.table.HashStringAndScreen(value)
+	if err != nil {
+		return err
+	}
+
+	index, err := s.table.Find(hash)
+	if err != nil {
+		if errors.Is(err, ErrKeyNotFound) {
+			s.table.Insert(index, hash)
+			return nil
+		}
+		return err
+	}
+
+	return ErrDuplicateKey
+}
+
+// UpdateBytes updates this sketch with given data
+// Only update when the value is not existing
+func (s *QuickSelectUpdateSketch) UpdateBytes(data []byte) error {
+	hash, err := s.table.HashBytesAndScreen(data)
+	if err != nil {
+		return err
+	}
+
+	index, err := s.table.Find(hash)
+	if err != nil {
+		if errors.Is(err, ErrKeyNotFound) {
+			s.table.Insert(index, hash)
+			return nil
+		}
+		return err
+	}
+
+	return ErrDuplicateKey
+}
+
+// Trim removes retained entries in excess of the nominal size k (if any)
+func (s *QuickSelectUpdateSketch) Trim() {
+	s.table.Trim()
+}
+
+// Reset resets the sketch to the initial empty state
+func (s *QuickSelectUpdateSketch) Reset() {
+	s.table.Reset()
+}
+
+// All returns an iterator over hash values in this sketch
+func (s *QuickSelectUpdateSketch) All() iter.Seq[uint64] {
+	return func(yield func(uint64) bool) {
+		for _, entry := range s.table.entries {
+			if entry != 0 {
+				if !yield(entry) {
+					return
+				}
+			}
+		}
+	}
+}

--- a/theta/update_sketch_test.go
+++ b/theta/update_sketch_test.go
@@ -1,0 +1,578 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package theta
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNewQuickSelectUpdateSketch(t *testing.T) {
+	t.Run("No Options And Empty", func(t *testing.T) {
+		updateSketch, err := NewQuickSelectUpdateSketch()
+		assert.NoError(t, err)
+
+		assert.True(t, updateSketch.IsEmpty())
+		assert.False(t, updateSketch.IsEstimationMode())
+		assert.Equal(t, 1.0, updateSketch.Theta())
+		assert.Equal(t, 0.0, updateSketch.Estimate())
+		lb, err := updateSketch.LowerBound(1)
+		assert.NoError(t, err)
+		assert.Equal(t, 0.0, lb)
+		ub, err := updateSketch.UpperBound(1)
+		assert.NoError(t, err)
+		assert.Equal(t, 0.0, ub)
+		assert.True(t, updateSketch.IsOrdered())
+	})
+
+	t.Run("With Options", func(t *testing.T) {
+		sketch, err := NewQuickSelectUpdateSketch(
+			WithUpdateSketchLgK(10),
+			WithUpdateSketchResizeFactor(ResizeX2),
+			WithUpdateSketchP(0.5),
+			WithUpdateSketchSeed(12345),
+		)
+		assert.NoError(t, err)
+		assert.NotNil(t, sketch)
+		assert.Equal(t, uint8(10), sketch.LgK())
+		assert.Equal(t, ResizeX2, sketch.ResizeFactor())
+		assert.Equal(t, float32(0.5), sketch.table.p)
+		assert.Equal(t, uint64(12345), sketch.table.seed)
+	})
+
+	t.Run("Non Empty No Retained Keys", func(t *testing.T) {
+		updateSketch, err := NewQuickSelectUpdateSketch(WithUpdateSketchP(0.001))
+		assert.NoError(t, err)
+		updateSketch.UpdateInt64(1)
+
+		assert.Zero(t, updateSketch.NumRetained())
+		assert.False(t, updateSketch.IsEmpty())
+		assert.True(t, updateSketch.IsEstimationMode())
+		assert.Equal(t, 0.0, updateSketch.Estimate())
+		lb, err := updateSketch.LowerBound(1)
+		assert.NoError(t, err)
+		assert.Equal(t, 0.0, lb)
+		ub, err := updateSketch.UpperBound(1)
+		assert.NoError(t, err)
+		assert.Greater(t, ub, 0.0)
+
+		updateSketch.Reset()
+		assert.True(t, updateSketch.IsEmpty())
+		assert.False(t, updateSketch.IsEstimationMode())
+		assert.Equal(t, 1.0, updateSketch.Theta())
+		assert.Equal(t, 0.0, updateSketch.Estimate())
+		lb, err = updateSketch.LowerBound(1)
+		assert.NoError(t, err)
+		assert.Equal(t, 0.0, lb)
+		ub, err = updateSketch.UpperBound(1)
+		assert.NoError(t, err)
+		assert.Equal(t, 0.0, ub)
+	})
+
+	t.Run("Invalid Lgk", func(t *testing.T) {
+		_, err := NewQuickSelectUpdateSketch(WithUpdateSketchLgK(3))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "lg_k must not be less than")
+
+		_, err = NewQuickSelectUpdateSketch(WithUpdateSketchLgK(30))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "lg_k must not be greater than")
+	})
+
+	t.Run("Invalid P", func(t *testing.T) {
+		_, err := NewQuickSelectUpdateSketch(WithUpdateSketchP(0.0))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "sampling probability must be between 0 and 1")
+
+		_, err = NewQuickSelectUpdateSketch(WithUpdateSketchP(1.5))
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "sampling probability must be between 0 and 1")
+	})
+}
+
+func TestQuickSelectUpdateSketch_Theta64(t *testing.T) {
+	sketch, err := NewQuickSelectUpdateSketch(WithUpdateSketchLgK(5))
+	assert.NoError(t, err)
+
+	// Empty sketch has MaxTheta
+	assert.Equal(t, MaxTheta, sketch.Theta64())
+
+	initialTheta := sketch.table.theta
+	assert.Equal(t, MaxTheta, initialTheta)
+
+	// Insert many values to trigger rebuild
+	for i := 0; i < 100; i++ {
+		_ = sketch.UpdateInt64(int64(i))
+	}
+
+	assert.Less(t, sketch.table.theta, initialTheta)
+	assert.Equal(t, sketch.table.theta, sketch.Theta64())
+}
+
+func TestQuickSelectUpdateSketch_SeedHash(t *testing.T) {
+	sketch, err := NewQuickSelectUpdateSketch(WithUpdateSketchSeed(12345))
+	assert.NoError(t, err)
+
+	seedHash, err := sketch.SeedHash()
+	assert.NoError(t, err)
+	assert.NotZero(t, seedHash)
+}
+
+func TestQuickSelectUpdateSketch_UpdateUint64(t *testing.T) {
+	sketch, err := NewQuickSelectUpdateSketch()
+	assert.NoError(t, err)
+
+	err = sketch.UpdateUint64(100)
+	assert.NoError(t, err)
+	assert.False(t, sketch.IsEmpty())
+
+	err = sketch.UpdateUint64(100)
+	assert.ErrorIs(t, err, ErrDuplicateKey)
+	assert.Equal(t, uint32(1), sketch.NumRetained())
+}
+
+func TestQuickSelectUpdateSketch_UpdateInt64(t *testing.T) {
+	sketch, err := NewQuickSelectUpdateSketch()
+	assert.NoError(t, err)
+
+	err = sketch.UpdateInt64(-100)
+	assert.NoError(t, err)
+	assert.False(t, sketch.IsEmpty())
+
+	err = sketch.UpdateInt64(-100)
+	assert.ErrorIs(t, err, ErrDuplicateKey)
+	assert.Equal(t, uint32(1), sketch.NumRetained())
+}
+
+func TestQuickSelectUpdateSketch_UpdateInt32(t *testing.T) {
+	sketch, err := NewQuickSelectUpdateSketch()
+	assert.NoError(t, err)
+
+	err = sketch.UpdateInt32(42)
+	assert.NoError(t, err)
+	assert.False(t, sketch.IsEmpty())
+
+	err = sketch.UpdateInt32(42)
+	assert.ErrorIs(t, err, ErrDuplicateKey)
+	assert.Equal(t, uint32(1), sketch.NumRetained())
+}
+
+func TestQuickSelectUpdateSketch_UpdateString(t *testing.T) {
+	sketch, err := NewQuickSelectUpdateSketch()
+	assert.NoError(t, err)
+
+	err = sketch.UpdateString("")
+	assert.ErrorIs(t, err, ErrUpdateEmptyString)
+
+	err = sketch.UpdateString("hello")
+	assert.NoError(t, err)
+	assert.False(t, sketch.IsEmpty())
+	assert.Equal(t, uint32(1), sketch.NumRetained())
+
+	err = sketch.UpdateString("hello")
+	assert.ErrorIs(t, err, ErrDuplicateKey)
+	assert.Equal(t, uint32(1), sketch.NumRetained())
+}
+
+func TestQuickSelectUpdateSketch_UpdateBytes(t *testing.T) {
+	sketch, err := NewQuickSelectUpdateSketch()
+	assert.NoError(t, err)
+
+	err = sketch.UpdateBytes([]byte{1, 2, 3})
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(1), sketch.NumRetained())
+
+	err = sketch.UpdateBytes([]byte{1, 2, 3})
+	assert.ErrorIs(t, err, ErrDuplicateKey)
+	assert.Equal(t, uint32(1), sketch.NumRetained())
+}
+
+func TestQuickSelectUpdateSketch_UpdateFloat64(t *testing.T) {
+	sketch, err := NewQuickSelectUpdateSketch()
+	assert.NoError(t, err)
+
+	err = sketch.UpdateFloat64(3.14)
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(1), sketch.NumRetained())
+
+	err = sketch.UpdateFloat64(3.14)
+	assert.ErrorIs(t, err, ErrDuplicateKey)
+	assert.Equal(t, uint32(1), sketch.NumRetained())
+}
+
+func TestQuickSelectUpdateSketch_UpdateFloat32(t *testing.T) {
+	sketch, err := NewQuickSelectUpdateSketch()
+	assert.NoError(t, err)
+
+	err = sketch.UpdateFloat32(3.14)
+	assert.NoError(t, err)
+	assert.Equal(t, uint32(1), sketch.NumRetained())
+
+	err = sketch.UpdateFloat32(3.14)
+	assert.ErrorIs(t, err, ErrDuplicateKey)
+	assert.Equal(t, uint32(1), sketch.NumRetained())
+}
+
+func TestQuickSelectUpdateSketch_Estimate(t *testing.T) {
+	sketch, err := NewQuickSelectUpdateSketch()
+	assert.NoError(t, err)
+
+	assert.Equal(t, 0.0, sketch.Estimate())
+
+	err = sketch.UpdateInt64(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 1.0, sketch.Estimate())
+}
+
+func TestQuickSelectUpdateSketch_LowerBound(t *testing.T) {
+	t.Run("Exact Mode", func(t *testing.T) {
+		sketch, err := NewQuickSelectUpdateSketch()
+		assert.NoError(t, err)
+
+		for i := 0; i < 10; i++ {
+			_ = sketch.UpdateInt64(int64(i))
+		}
+
+		lb, err := sketch.LowerBound(1)
+		assert.NoError(t, err)
+		assert.Equal(t, float64(sketch.NumRetained()), lb)
+
+		for _, stdDevs := range []uint8{1, 2, 3} {
+			lb, err = sketch.LowerBound(stdDevs)
+			assert.NoError(t, err)
+			assert.Equal(t, float64(sketch.NumRetained()), lb)
+		}
+	})
+
+	t.Run("Estimation Mode", func(t *testing.T) {
+		sketch, err := NewQuickSelectUpdateSketch(WithUpdateSketchLgK(5))
+		assert.NoError(t, err)
+
+		// Add enough items to trigger estimation mode
+		for i := 0; i < 100; i++ {
+			_ = sketch.UpdateInt64(int64(i))
+		}
+
+		assert.True(t, sketch.IsEstimationMode())
+
+		estimate := sketch.Estimate()
+		lb, err := sketch.LowerBound(1)
+		assert.NoError(t, err)
+		assert.LessOrEqual(t, lb, estimate)
+
+		lb1, err := sketch.LowerBound(1)
+		assert.NoError(t, err)
+		lb2, err := sketch.LowerBound(2)
+		assert.NoError(t, err)
+		lb3, err := sketch.LowerBound(3)
+		assert.NoError(t, err)
+
+		assert.GreaterOrEqual(t, lb1, lb2)
+		assert.GreaterOrEqual(t, lb2, lb3)
+	})
+
+	t.Run("Invalid NumStdDevs", func(t *testing.T) {
+		sketch, err := NewQuickSelectUpdateSketch(WithUpdateSketchLgK(5))
+		assert.NoError(t, err)
+
+		// Add enough items to trigger estimation mode
+		for i := 0; i < 100; i++ {
+			_ = sketch.UpdateInt64(int64(i))
+		}
+
+		_, err = sketch.LowerBound(0)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "numStdDevs must be 1, 2 or 3")
+
+		_, err = sketch.LowerBound(4)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "numStdDevs must be 1, 2 or 3")
+	})
+}
+
+func TestQuickSelectUpdateSketch_UpperBound(t *testing.T) {
+	t.Run("Exact Mode", func(t *testing.T) {
+		sketch, err := NewQuickSelectUpdateSketch()
+		assert.NoError(t, err)
+
+		ub, err := sketch.UpperBound(1)
+		assert.NoError(t, err)
+		assert.Equal(t, 0.0, ub)
+
+		for i := 0; i < 10; i++ {
+			_ = sketch.UpdateInt64(int64(i))
+		}
+
+		ub, err = sketch.UpperBound(1)
+		assert.NoError(t, err)
+		assert.Equal(t, float64(sketch.NumRetained()), ub)
+
+		for _, stdDevs := range []uint8{1, 2, 3} {
+			ub, err = sketch.UpperBound(stdDevs)
+			assert.NoError(t, err)
+			assert.Equal(t, float64(sketch.NumRetained()), ub)
+		}
+	})
+
+	t.Run("Estimation Mode", func(t *testing.T) {
+		sketch, err := NewQuickSelectUpdateSketch(WithUpdateSketchLgK(5))
+		assert.NoError(t, err)
+
+		// Add enough items to trigger estimation mode
+		for i := 0; i < 100; i++ {
+			_ = sketch.UpdateInt64(int64(i))
+		}
+
+		assert.True(t, sketch.IsEstimationMode())
+
+		estimate := sketch.Estimate()
+		ub, err := sketch.UpperBound(1)
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, ub, estimate)
+
+		// Higher standard deviations should give higher upper bounds
+		ub1, err := sketch.UpperBound(1)
+		assert.NoError(t, err)
+		ub2, err := sketch.UpperBound(2)
+		assert.NoError(t, err)
+		ub3, err := sketch.UpperBound(3)
+		assert.NoError(t, err)
+
+		assert.LessOrEqual(t, ub1, ub2)
+		assert.LessOrEqual(t, ub2, ub3)
+	})
+
+	t.Run("Invalid NumStdDevs", func(t *testing.T) {
+		sketch, err := NewQuickSelectUpdateSketch(WithUpdateSketchLgK(5))
+		assert.NoError(t, err)
+
+		// Add enough items to trigger estimation mode
+		for i := 0; i < 100; i++ {
+			_ = sketch.UpdateInt64(int64(i))
+		}
+
+		_, err = sketch.UpperBound(0)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "numStdDevs must be 1, 2 or 3")
+
+		_, err = sketch.UpperBound(4)
+		assert.Error(t, err)
+		assert.Contains(t, err.Error(), "numStdDevs must be 1, 2 or 3")
+	})
+}
+
+func TestQuickSelectUpdateSketch_IsEstimationMode(t *testing.T) {
+	t.Run("Exact Mode", func(t *testing.T) {
+		sketch, err := NewQuickSelectUpdateSketch()
+		assert.NoError(t, err)
+		assert.False(t, sketch.IsEstimationMode())
+		assert.Equal(t, MaxTheta, sketch.Theta64())
+
+		for i := 0; i < 10; i++ {
+			_ = sketch.UpdateInt64(int64(i))
+		}
+		assert.False(t, sketch.IsEstimationMode())
+		assert.Equal(t, MaxTheta, sketch.Theta64())
+	})
+
+	t.Run("Estimation Mode", func(t *testing.T) {
+		sketch, err := NewQuickSelectUpdateSketch(WithUpdateSketchLgK(5))
+		assert.NoError(t, err)
+		assert.False(t, sketch.IsEstimationMode())
+
+		// Add enough items to trigger estimation mode
+		for i := 0; i < 100; i++ {
+			_ = sketch.UpdateInt64(int64(i))
+		}
+
+		assert.True(t, sketch.IsEstimationMode())
+	})
+}
+
+func TestQuickSelectUpdateSketch_Theta(t *testing.T) {
+	sketch, err := NewQuickSelectUpdateSketch(WithUpdateSketchLgK(5))
+	assert.NoError(t, err)
+	assert.Equal(t, 1.0, sketch.Theta())
+
+	// Add enough items to trigger rebuild
+	for i := 0; i < 100; i++ {
+		_ = sketch.UpdateInt64(int64(i))
+	}
+
+	theta := sketch.Theta()
+	assert.Less(t, theta, 1.0)
+}
+
+func TestQuickSelectUpdateSketch_All(t *testing.T) {
+	sketch, err := NewQuickSelectUpdateSketch()
+	assert.NoError(t, err)
+
+	count := 0
+	for range sketch.All() {
+		count++
+	}
+	assert.Equal(t, 0, count)
+
+	// Add items and verify iteration
+	values := []int64{1, 2, 3, 4, 5}
+	for _, v := range values {
+		_ = sketch.UpdateInt64(v)
+	}
+	count = 0
+	for range sketch.All() {
+		count++
+	}
+	assert.Equal(t, len(values), count)
+
+	seen := make(map[uint64]bool)
+	for hash := range sketch.All() {
+		seen[hash] = true
+		assert.NotZero(t, hash)
+	}
+	assert.Equal(t, len(values), len(seen))
+
+	// Test early break
+	count = 0
+	for range sketch.All() {
+		count++
+		if count == 2 {
+			break
+		}
+	}
+	assert.Equal(t, 2, count)
+}
+
+func TestQuickSelectUpdateSketch_String(t *testing.T) {
+	t.Run("Without Items", func(t *testing.T) {
+		sketch, err := NewQuickSelectUpdateSketch(WithUpdateSketchLgK(8))
+		assert.NoError(t, err)
+
+		for i := 0; i < 10; i++ {
+			_ = sketch.UpdateInt64(int64(i))
+		}
+
+		result := sketch.String(false)
+
+		assert.Contains(t, result, "### Theta sketch summary:")
+		assert.Contains(t, result, "num retained entries : 10")
+		assert.Contains(t, result, "empty?               : false")
+		assert.Contains(t, result, "ordered?             : false")
+		assert.Contains(t, result, "estimation mode?     : false")
+		assert.Contains(t, result, "lg nominal size      : 8")
+		assert.Contains(t, result, "### End sketch summary")
+
+		assert.NotContains(t, result, "### Retained entries")
+	})
+
+	t.Run("With Items", func(t *testing.T) {
+		sketch, err := NewQuickSelectUpdateSketch()
+		assert.NoError(t, err)
+
+		_ = sketch.UpdateInt64(100)
+		_ = sketch.UpdateInt64(200)
+
+		result := sketch.String(true)
+
+		assert.Contains(t, result, "### Theta sketch summary:")
+		assert.Contains(t, result, "num retained entries : 2")
+		assert.Contains(t, result, "### End sketch summary")
+
+		assert.Contains(t, result, "### Retained entries")
+		assert.Contains(t, result, "### End retained entries")
+	})
+}
+
+func TestQuickSelectUpdateSketch_SingleItem(t *testing.T) {
+	updateSketch, err := NewQuickSelectUpdateSketch()
+	assert.NoError(t, err)
+	updateSketch.UpdateInt64(1)
+
+	assert.False(t, updateSketch.IsEmpty())
+	assert.False(t, updateSketch.IsEstimationMode())
+	assert.Equal(t, 1.0, updateSketch.Theta())
+	assert.Equal(t, 1.0, updateSketch.Estimate())
+	lb, err := updateSketch.LowerBound(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 1.0, lb)
+	ub, err := updateSketch.UpperBound(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 1.0, ub)
+	assert.True(t, updateSketch.IsOrdered())
+}
+
+func TestQuickSelectUpdateSketch_ResizeExact(t *testing.T) {
+	updateSketch, err := NewQuickSelectUpdateSketch()
+	assert.NoError(t, err)
+
+	for i := 0; i < 2000; i++ {
+		updateSketch.UpdateInt64(int64(i))
+	}
+
+	assert.False(t, updateSketch.IsEmpty())
+	assert.False(t, updateSketch.IsEstimationMode())
+	assert.Equal(t, 1.0, updateSketch.Theta())
+	assert.Equal(t, 2000.0, updateSketch.Estimate())
+	lb, err := updateSketch.LowerBound(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 2000.0, lb)
+	ub, err := updateSketch.UpperBound(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 2000.0, ub)
+	assert.False(t, updateSketch.IsOrdered())
+
+	updateSketch.Reset()
+	assert.True(t, updateSketch.IsEmpty())
+	assert.False(t, updateSketch.IsEstimationMode())
+	assert.Equal(t, 1.0, updateSketch.Theta())
+	assert.Equal(t, 0.0, updateSketch.Estimate())
+	lb, err = updateSketch.LowerBound(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 0.0, lb)
+	ub, err = updateSketch.UpperBound(1)
+	assert.NoError(t, err)
+	assert.Equal(t, 0.0, ub)
+	assert.True(t, updateSketch.IsOrdered())
+}
+
+func TestQuickSelectUpdateSketch_Estimation(t *testing.T) {
+	updateSketch, err := NewQuickSelectUpdateSketch(WithUpdateSketchResizeFactor(ResizeX1))
+	assert.NoError(t, err)
+
+	n := 8000
+	for i := 0; i < n; i++ {
+		updateSketch.UpdateInt64(int64(i))
+	}
+
+	assert.False(t, updateSketch.IsEmpty())
+	assert.True(t, updateSketch.IsEstimationMode())
+	assert.Less(t, updateSketch.Theta(), 1.0)
+	assert.InEpsilon(t, n, updateSketch.Estimate(), 0.01)
+	lb, err := updateSketch.LowerBound(1)
+	assert.NoError(t, err)
+	assert.Less(t, lb, float64(n))
+	ub, err := updateSketch.UpperBound(1)
+	assert.NoError(t, err)
+	assert.Greater(t, ub, float64(n))
+
+	k := uint32(1) << DefaultLgK
+	assert.GreaterOrEqual(t, updateSketch.NumRetained(), k)
+
+	updateSketch.Trim()
+	assert.Equal(t, k, updateSketch.NumRetained())
+}


### PR DESCRIPTION
resolve: https://github.com/apache/datasketches-go/issues/52

Adding quick select based update theta sketch.

I used functional options pattern which is go-idiom way in constructor when optional parameters exist.