### PR TITLE
feat: adding getters for theta hashtable

### DIFF
--- a/theta/hashtable.go
+++ b/theta/hashtable.go
@@ -20,6 +20,7 @@ package theta
 import (
 	"errors"
 	"fmt"
+	"iter"
 	"math"
 
 	"github.com/apache/datasketches-go/internal"
@@ -320,6 +321,17 @@ func (t *Hashtable) SeedHash() (uint16, error) {
 // Theta64 returns theta as a positive integer between 0 and math.MaxInt64
 func (t *Hashtable) Theta64() uint64 {
 	return t.theta
+}
+
+// All returns a sequence of all non-zero entries in the hashtable, allowing iteration with a yield function.
+func (t *Hashtable) All() iter.Seq[uint64] {
+	return func(yield func(uint64) bool) {
+		for _, entry := range t.entries {
+			if !yield(entry) {
+				return
+			}
+		}
+	}
 }
 
 func consolidateNonEmpty(entries []uint64, size, num int) {

--- a/theta/hashtable_test.go
+++ b/theta/hashtable_test.go
@@ -632,3 +632,59 @@ func TestHashtable_SeedHash(t *testing.T) {
 		}
 	})
 }
+
+func TestHashtable_All(t *testing.T) {
+	t.Run("empty table", func(t *testing.T) {
+		ht := NewHashtable(4, 4, ResizeX1, 1.0, MaxTheta, DefaultSeed, true)
+
+		var entries []uint64
+		for entry := range ht.All() {
+			entries = append(entries, entry)
+		}
+
+		for _, entry := range entries {
+			assert.Zero(t, entry)
+		}
+	})
+
+	t.Run("table with entries", func(t *testing.T) {
+		ht := NewHashtable(4, 4, ResizeX1, 1.0, MaxTheta, DefaultSeed, true)
+
+		keys := []uint64{12345, 67890, 11111}
+		for _, key := range keys {
+			index, _ := ht.Find(key)
+			ht.entries[index] = key
+			ht.numEntries++
+		}
+
+		var entries []uint64
+		for entry := range ht.All() {
+			entries = append(entries, entry)
+		}
+
+		for _, key := range keys {
+			assert.Contains(t, entries, key)
+		}
+	})
+
+	t.Run("early termination", func(t *testing.T) {
+		ht := NewHashtable(4, 4, ResizeX1, 1.0, MaxTheta, DefaultSeed, true)
+
+		for i := uint64(1); i <= 5; i++ {
+			index, _ := ht.Find(i * 1000)
+			ht.entries[index] = i * 1000
+			ht.numEntries++
+		}
+
+		count := 0
+		for range ht.All() {
+			count++
+			if count == 2 {
+				break
+			}
+		}
+
+		assert.Equal(t, 2, count)
+	})
+
+}


### PR DESCRIPTION
I'm working on tuple sketch.

I found that tuple sketch needs some getters of theta hashtable.

I didn't add test function for simple getters. but if you want to add test cases, i will do.

BTW, I finished writing theta sketch profiling code. But running profiling is quite long. 