### PR TITLE
Disable the x-serialisation test if the sketch files are missing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+serialization_test_data/**.sk export-ignore

--- a/cpc/cpc_sketch_serialization_test.go
+++ b/cpc/cpc_sketch_serialization_test.go
@@ -51,7 +51,13 @@ func TestJavaCompat(t *testing.T) {
 		nArr := []int{0, 100, 200, 2000, 20000}
 		flavorArr := []CpcFlavor{CpcFlavorEmpty, CpcFlavorSparse, CpcFlavorHybrid, CpcFlavorPinned, CpcFlavorSliding}
 		for flavorIdx, n := range nArr {
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/cpc_n%d_java.sk", internal.JavaPath, n))
+			filename := fmt.Sprintf("%s/cpc_n%d_java.sk", internal.JavaPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("Java file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 			sketch, err := NewCpcSketchFromSliceWithDefault(bytes)
 			assert.NoError(t, err)

--- a/filters/bloom_filter_serialization_test.go
+++ b/filters/bloom_filter_serialization_test.go
@@ -196,7 +196,13 @@ func TestJavaCompat(t *testing.T) {
 		}
 
 		for _, tc := range testCases {
-			b, err := os.ReadFile(fmt.Sprintf("%s/bf_n%d_h%d_java.sk", internal.JavaPath, tc.n, tc.numHashes))
+			filename := fmt.Sprintf("%s/bf_n%d_h%d_java.sk", internal.JavaPath, tc.n, tc.numHashes)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("Java file not found: %s", filename)
+				return
+			}
+			b, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 
 			bf, err := NewBloomFilterFromSlice(b)

--- a/frequencies/sketch_serialization_test.go
+++ b/frequencies/sketch_serialization_test.go
@@ -140,7 +140,13 @@ func TestJavaCompat(t *testing.T) {
 	t.Run("Long ut8", func(t *testing.T) {
 		nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range nArr {
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_long_n%d_java.sk", internal.JavaPath, n))
+			filename := fmt.Sprintf("%s/frequent_long_n%d_java.sk", internal.JavaPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("Java file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 			sketch, err := NewLongsSketchFromSlice(bytes)
 			if err != nil {
@@ -164,7 +170,13 @@ func TestJavaCompat(t *testing.T) {
 	t.Run("String Frequency", func(t *testing.T) {
 		nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range nArr {
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_n%d_java.sk", internal.JavaPath, n))
+			filename := fmt.Sprintf("%s/frequent_string_n%d_java.sk", internal.JavaPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("Java file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 			sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 			if err != nil {
@@ -186,7 +198,13 @@ func TestJavaCompat(t *testing.T) {
 	})
 
 	t.Run("String utf8", func(t *testing.T) {
-		bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_utf8_java.sk", internal.JavaPath))
+		filename := fmt.Sprintf("%s/frequent_string_utf8_java.sk", internal.JavaPath)
+		// Skip if file doesn't exist
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			t.Skipf("Java file not found: %s", filename)
+			return
+		}
+		bytes, err := os.ReadFile(filename)
 		assert.NoError(t, err)
 		sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 		if err != nil {
@@ -219,7 +237,13 @@ func TestJavaCompat(t *testing.T) {
 	})
 
 	t.Run("String ascii", func(t *testing.T) {
-		bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_ascii_java.sk", internal.JavaPath))
+		filename := fmt.Sprintf("%s/frequent_string_ascii_java.sk", internal.JavaPath)
+		// Skip if file doesn't exist
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			t.Skipf("Java file not found: %s", filename)
+			return
+		}
+		bytes, err := os.ReadFile(filename)
 		assert.NoError(t, err)
 		sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 		if err != nil {
@@ -247,7 +271,13 @@ func TestCppCompat(t *testing.T) {
 	t.Run("Long Frequency", func(t *testing.T) {
 		nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range nArr {
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_long_n%d_cpp.sk", internal.CppPath, n))
+			filename := fmt.Sprintf("%s/frequent_long_n%d_cpp.sk", internal.CppPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("C++ file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 			sketch, err := NewLongsSketchFromSlice(bytes)
 			if err != nil {
@@ -271,7 +301,13 @@ func TestCppCompat(t *testing.T) {
 	t.Run("String Frequency", func(t *testing.T) {
 		nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range nArr {
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_n%d_cpp.sk", internal.CppPath, n))
+			filename := fmt.Sprintf("%s/frequent_string_n%d_cpp.sk", internal.CppPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("C++ file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 			sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 			if err != nil {
@@ -293,7 +329,13 @@ func TestCppCompat(t *testing.T) {
 	})
 
 	t.Run("String utf8", func(t *testing.T) {
-		bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_utf8_cpp.sk", internal.CppPath))
+		filename := fmt.Sprintf("%s/frequent_string_utf8_cpp.sk", internal.CppPath)
+		// Skip if file doesn't exist
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			t.Skipf("C++ file not found: %s", filename)
+			return
+		}
+		bytes, err := os.ReadFile(filename)
 		assert.NoError(t, err)
 		sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 		if err != nil {
@@ -326,7 +368,13 @@ func TestCppCompat(t *testing.T) {
 	})
 
 	t.Run("String ascii", func(t *testing.T) {
-		bytes, err := os.ReadFile(fmt.Sprintf("%s/frequent_string_ascii_cpp.sk", internal.CppPath))
+		filename := fmt.Sprintf("%s/frequent_string_ascii_cpp.sk", internal.CppPath)
+		// Skip if file doesn't exist
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			t.Skipf("C++ file not found: %s", filename)
+			return
+		}
+		bytes, err := os.ReadFile(filename)
 		assert.NoError(t, err)
 		sketch, err := NewFrequencyItemsSketchFromSlice[string](bytes, common.ItemSketchStringHasher{}, common.ItemSketchStringSerDe{})
 		if err != nil {

--- a/hll/hll_sketch_serialization_test.go
+++ b/hll/hll_sketch_serialization_test.go
@@ -69,7 +69,13 @@ func TestJavaCompat(t *testing.T) {
 	t.Run("Java Hll4", func(t *testing.T) {
 		nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range nArr {
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/hll4_n%d_java.sk", internal.JavaPath, n))
+			filename := fmt.Sprintf("%s/hll4_n%d_java.sk", internal.JavaPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("Java file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 			sketch, err := NewHllSketchFromSlice(bytes, true)
 			if err != nil {
@@ -86,7 +92,13 @@ func TestJavaCompat(t *testing.T) {
 	t.Run("Java Hll6", func(t *testing.T) {
 		nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range nArr {
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/hll6_n%d_java.sk", internal.JavaPath, n))
+			filename := fmt.Sprintf("%s/hll6_n%d_java.sk", internal.JavaPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("Java file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 
 			sketch, err := NewHllSketchFromSlice(bytes, true)
@@ -104,7 +116,13 @@ func TestJavaCompat(t *testing.T) {
 	t.Run("Java Hll8", func(t *testing.T) {
 		nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range nArr {
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/hll8_n%d_java.sk", internal.JavaPath, n))
+			filename := fmt.Sprintf("%s/hll8_n%d_java.sk", internal.JavaPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("Java file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 			sketch, err := NewHllSketchFromSlice(bytes, true)
 			if err != nil {
@@ -123,7 +141,13 @@ func TestCppCompat(t *testing.T) {
 	t.Run("Cpp Hll4", func(t *testing.T) {
 		nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range nArr {
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/hll4_n%d_cpp.sk", internal.CppPath, n))
+			filename := fmt.Sprintf("%s/hll4_n%d_cpp.sk", internal.CppPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("C++ file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 			sketch, err := NewHllSketchFromSlice(bytes, true)
 			if err != nil {
@@ -140,7 +164,13 @@ func TestCppCompat(t *testing.T) {
 	t.Run("Cpp Hll6", func(t *testing.T) {
 		nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range nArr {
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/hll6_n%d_cpp.sk", internal.CppPath, n))
+			filename := fmt.Sprintf("%s/hll6_n%d_cpp.sk", internal.CppPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("C++ file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 
 			sketch, err := NewHllSketchFromSlice(bytes, true)
@@ -158,7 +188,13 @@ func TestCppCompat(t *testing.T) {
 	t.Run("Cpp Hll8", func(t *testing.T) {
 		nArr := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range nArr {
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/hll8_n%d_cpp.sk", internal.CppPath, n))
+			filename := fmt.Sprintf("%s/hll8_n%d_cpp.sk", internal.CppPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("C++ file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 			sketch, err := NewHllSketchFromSlice(bytes, true)
 			if err != nil {
@@ -192,7 +228,13 @@ func TestGoCompat(t *testing.T) {
 		{
 			sl4, err := hll4.ToCompactSlice()
 			assert.NoError(t, err)
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/hll4_n%d_java.sk", internal.JavaPath, n))
+			filename := fmt.Sprintf("%s/hll4_n%d_java.sk", internal.JavaPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("Java file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 			assert.Equal(t, bytes, sl4)
 		}
@@ -200,7 +242,13 @@ func TestGoCompat(t *testing.T) {
 		{
 			sl6, err := hll6.ToCompactSlice()
 			assert.NoError(t, err)
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/hll6_n%d_java.sk", internal.JavaPath, n))
+			filename := fmt.Sprintf("%s/hll6_n%d_java.sk", internal.JavaPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("Java file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 			assert.Equal(t, bytes, sl6)
 		}
@@ -208,7 +256,13 @@ func TestGoCompat(t *testing.T) {
 		{
 			sl8, err := hll8.ToCompactSlice()
 			assert.NoError(t, err)
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/hll8_n%d_java.sk", internal.JavaPath, n))
+			filename := fmt.Sprintf("%s/hll8_n%d_java.sk", internal.JavaPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("Java file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 			assert.Equal(t, bytes, sl8)
 		}
@@ -216,7 +270,13 @@ func TestGoCompat(t *testing.T) {
 		{
 			sl4, err := hll4.ToCompactSlice()
 			assert.NoError(t, err)
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/hll4_n%d_cpp.sk", internal.CppPath, n))
+			filename := fmt.Sprintf("%s/hll4_n%d_cpp.sk", internal.CppPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("C++ file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 			assert.Equal(t, bytes, sl4)
 		}
@@ -224,7 +284,13 @@ func TestGoCompat(t *testing.T) {
 		{
 			sl6, err := hll6.ToCompactSlice()
 			assert.NoError(t, err)
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/hll6_n%d_cpp.sk", internal.CppPath, n))
+			filename := fmt.Sprintf("%s/hll6_n%d_cpp.sk", internal.CppPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("C++ file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 
 			// clear compact flag for C++ sketches when in HLL mode tgt6
@@ -238,7 +304,13 @@ func TestGoCompat(t *testing.T) {
 		{
 			sl8, err := hll8.ToCompactSlice()
 			assert.NoError(t, err)
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/hll8_n%d_cpp.sk", internal.CppPath, n))
+			filename := fmt.Sprintf("%s/hll8_n%d_cpp.sk", internal.CppPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("C++ file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 
 			// clear compact flag for C++ sketches when in HLL mode tgt8

--- a/kll/items_sletch_serialization_test.go
+++ b/kll/items_sletch_serialization_test.go
@@ -71,7 +71,13 @@ func TestJavaCompat(t *testing.T) {
 		comparatorString := common.ItemSketchStringComparator(false)
 		for _, n := range nArr {
 			digits := numDigits(n)
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/kll_string_n%d_java.sk", internal.JavaPath, n))
+			filename := fmt.Sprintf("%s/kll_string_n%d_java.sk", internal.JavaPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("Java file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 			sketch, err := NewKllItemsSketchFromSlice[string](bytes, comparatorString, serde)
 			if err != nil {
@@ -119,7 +125,13 @@ func TestJavaCompat(t *testing.T) {
 		serde := common.ItemSketchDoubleSerDe{}
 		comparatorDouble := common.ItemSketchDoubleComparator(false)
 		for _, n := range nArr {
-			bytes, err := os.ReadFile(fmt.Sprintf("%s/kll_double_n%d_java.sk", internal.JavaPath, n))
+			filename := fmt.Sprintf("%s/kll_double_n%d_java.sk", internal.JavaPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("Java file not found: %s", filename)
+				return
+			}
+			bytes, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 			sketch, err := NewKllItemsSketchFromSlice[float64](bytes, comparatorDouble, serde)
 			if err != nil {

--- a/theta/sketch_serialization_test.go
+++ b/theta/sketch_serialization_test.go
@@ -112,7 +112,13 @@ func TestJavaCompat(t *testing.T) {
 	t.Run("theta sketch", func(t *testing.T) {
 		ns := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range ns {
-			b, err := os.ReadFile(fmt.Sprintf("%s/theta_n%d_java.sk", internal.JavaPath, n))
+			filename := fmt.Sprintf("%s/theta_n%d_java.sk", internal.JavaPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("Java file not found: %s", filename)
+				return
+			}
+			b, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 
 			sketch, err := Decode(b, DefaultSeed)
@@ -136,7 +142,13 @@ func TestJavaCompat(t *testing.T) {
 	t.Run("theta sketch compressed", func(t *testing.T) {
 		ns := []int{10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range ns {
-			b, err := os.ReadFile(fmt.Sprintf("%s/theta_compressed_n%d_java.sk", internal.JavaPath, n))
+			filename := fmt.Sprintf("%s/theta_compressed_n%d_java.sk", internal.JavaPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("Java file not found: %s", filename)
+				return
+			}
+			b, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 
 			sketch, err := Decode(b, DefaultSeed)
@@ -157,7 +169,13 @@ func TestJavaCompat(t *testing.T) {
 	})
 
 	t.Run("theta sketch non-empty no entries", func(t *testing.T) {
-		b, err := os.ReadFile(fmt.Sprintf("%s/theta_non_empty_no_entries_java.sk", internal.JavaPath))
+		filename := fmt.Sprintf("%s/theta_non_empty_no_entries_java.sk", internal.JavaPath)
+		// Skip if file doesn't exist
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			t.Skipf("Java file not found: %s", filename)
+			return
+		}
+		b, err := os.ReadFile(filename)
 		assert.NoError(t, err)
 
 		sketch, err := Decode(b, DefaultSeed)
@@ -378,7 +396,13 @@ func TestCPPCompat(t *testing.T) {
 	t.Run("theta sketch", func(t *testing.T) {
 		ns := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range ns {
-			b, err := os.ReadFile(fmt.Sprintf("%s/theta_n%d_cpp.sk", internal.CppPath, n))
+			filename := fmt.Sprintf("%s/theta_n%d_cpp.sk", internal.CppPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("C++ file not found: %s", filename)
+				return
+			}
+			b, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 
 			sketch, err := Decode(b, DefaultSeed)
@@ -402,7 +426,13 @@ func TestCPPCompat(t *testing.T) {
 	t.Run("theta sketch compressed", func(t *testing.T) {
 		ns := []int{10, 100, 1000, 10000, 100000, 1000000}
 		for _, n := range ns {
-			b, err := os.ReadFile(fmt.Sprintf("%s/theta_compressed_n%d_cpp.sk", internal.CppPath, n))
+			filename := fmt.Sprintf("%s/theta_compressed_n%d_cpp.sk", internal.CppPath, n)
+			// Skip if file doesn't exist
+			if _, err := os.Stat(filename); os.IsNotExist(err) {
+				t.Skipf("C++ file not found: %s", filename)
+				return
+			}
+			b, err := os.ReadFile(filename)
 			assert.NoError(t, err)
 
 			sketch, err := Decode(b, DefaultSeed)
@@ -423,7 +453,13 @@ func TestCPPCompat(t *testing.T) {
 	})
 
 	t.Run("theta sketch non-empty no entries", func(t *testing.T) {
-		b, err := os.ReadFile(fmt.Sprintf("%s/theta_non_empty_no_entries_cpp.sk", internal.CppPath))
+		filename := fmt.Sprintf("%s/theta_non_empty_no_entries_cpp.sk", internal.CppPath)
+		// Skip if file doesn't exist
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			t.Skipf("C++ file not found: %s", filename)
+			return
+		}
+		b, err := os.ReadFile(filename)
 		assert.NoError(t, err)
 
 		sketch, err := Decode(b, DefaultSeed)

--- a/tuple/sketch_serialization_test.go
+++ b/tuple/sketch_serialization_test.go
@@ -78,7 +78,13 @@ func TestGenerateGoBinariesForCompatibilityTesting(t *testing.T) {
 func TestJavaCompat(t *testing.T) {
 	ns := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 	for _, n := range ns {
-		b, err := os.ReadFile(fmt.Sprintf("%s/tuple_int_n%d_java.sk", internal.JavaPath, n))
+		filename := fmt.Sprintf("%s/tuple_int_n%d_java.sk", internal.JavaPath, n)
+		// Skip if file doesn't exist
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			t.Skipf("Java file not found: %s", filename)
+			return
+		}
+		b, err := os.ReadFile(filename)
 		assert.NoError(t, err)
 
 		buf := bytes.NewBuffer(b)
@@ -98,7 +104,13 @@ func TestJavaCompat(t *testing.T) {
 func TestCPPCompat(t *testing.T) {
 	ns := []int{0, 1, 10, 100, 1000, 10000, 100000, 1000000}
 	for _, n := range ns {
-		b, err := os.ReadFile(fmt.Sprintf("%s/tuple_int_n%d_cpp.sk", internal.CppPath, n))
+		filename := fmt.Sprintf("%s/tuple_int_n%d_cpp.sk", internal.CppPath, n)
+		// Skip if file doesn't exist
+		if _, err := os.Stat(filename); os.IsNotExist(err) {
+			t.Skipf("C++ file not found: %s", filename)
+			return
+		}
+		b, err := os.ReadFile(filename)
 		assert.NoError(t, err)
 
 		buf := bytes.NewBuffer(b)


### PR DESCRIPTION
Make x-serialisation test skip if no sketch is present in the corresponding serialized datasets.

Exclude serialized datasets from the archive process - e.g. not included in releases (but can still be generated)