### PR TITLE
feat: implement generic ReservoirItemsSketch for sampling package

### DIFF
--- a/examples/reservoir_example_test.go
+++ b/examples/reservoir_example_test.go
@@ -36,11 +36,11 @@ func TestReservoirSamplingWithIntegers(t *testing.T) {
 	}
 
 	// The sketch maintains exactly k samples
-	assert.Equal(t, 10, sketch.GetNumSamples())
-	assert.Equal(t, int64(1000), sketch.GetN())
+	assert.Equal(t, 10, sketch.NumSamples())
+	assert.Equal(t, int64(1000), sketch.N())
 
-	samples := sketch.GetSamples()
-	fmt.Printf("Sampled %d integers from stream of %d\n", len(samples), sketch.GetN())
+	samples := sketch.Samples()
+	fmt.Printf("Sampled %d integers from stream of %d\n", len(samples), sketch.N())
 	fmt.Printf("Samples: %v\n", samples)
 }
 
@@ -54,8 +54,8 @@ func TestReservoirSamplingWithStrings(t *testing.T) {
 		sketch.Update(word)
 	}
 
-	assert.Equal(t, 5, sketch.GetNumSamples())
-	fmt.Printf("Sampled words: %v\n", sketch.GetSamples())
+	assert.Equal(t, 5, sketch.NumSamples())
+	fmt.Printf("Sampled words: %v\n", sketch.Samples())
 }
 
 func TestReservoirSamplingWithStructs(t *testing.T) {
@@ -75,8 +75,8 @@ func TestReservoirSamplingWithStructs(t *testing.T) {
 		})
 	}
 
-	assert.Equal(t, 3, sketch.GetNumSamples())
-	fmt.Printf("Sampled log entries: %+v\n", sketch.GetSamples())
+	assert.Equal(t, 3, sketch.NumSamples())
+	fmt.Printf("Sampled log entries: %+v\n", sketch.Samples())
 }
 
 func TestReservoirUnion(t *testing.T) {
@@ -98,9 +98,9 @@ func TestReservoirUnion(t *testing.T) {
 	union.UpdateSketch(node1)
 	union.UpdateSketch(node2)
 
-	result, err := union.GetResult()
+	result, err := union.Result()
 	assert.NoError(t, err)
 
-	assert.Equal(t, 10, result.GetNumSamples())
-	fmt.Printf("Union result: %d samples from combined stream\n", result.GetNumSamples())
+	assert.Equal(t, 10, result.NumSamples())
+	fmt.Printf("Union result: %d samples from combined stream\n", result.NumSamples())
 }

--- a/sampling/reservoir_items_sketch.go
+++ b/sampling/reservoir_items_sketch.go
@@ -79,23 +79,23 @@ func (s *ReservoirItemsSketch[T]) Update(item T) {
 	s.n++
 }
 
-// GetK returns the maximum reservoir capacity.
-func (s *ReservoirItemsSketch[T]) GetK() int {
+// K returns the maximum reservoir capacity.
+func (s *ReservoirItemsSketch[T]) K() int {
 	return s.k
 }
 
-// GetN returns the total number of items seen by the sketch.
-func (s *ReservoirItemsSketch[T]) GetN() int64 {
+// N returns the total number of items seen by the sketch.
+func (s *ReservoirItemsSketch[T]) N() int64 {
 	return s.n
 }
 
-// GetNumSamples returns the number of items currently in the reservoir.
-func (s *ReservoirItemsSketch[T]) GetNumSamples() int {
+// NumSamples returns the number of items currently in the reservoir.
+func (s *ReservoirItemsSketch[T]) NumSamples() int {
 	return len(s.data)
 }
 
-// GetSamples returns a copy of the items in the reservoir.
-func (s *ReservoirItemsSketch[T]) GetSamples() []T {
+// Samples returns a copy of the items in the reservoir.
+func (s *ReservoirItemsSketch[T]) Samples() []T {
 	result := make([]T, len(s.data))
 	copy(result, s.data)
 	return result

--- a/sampling/reservoir_items_sketch_test.go
+++ b/sampling/reservoir_items_sketch_test.go
@@ -27,8 +27,8 @@ func TestNewReservoirItemsSketch(t *testing.T) {
 	sketch, err := NewReservoirItemsSketch[int64](10)
 	assert.NoError(t, err)
 	assert.NotNil(t, sketch)
-	assert.Equal(t, 10, sketch.GetK())
-	assert.Equal(t, int64(0), sketch.GetN())
+	assert.Equal(t, 10, sketch.K())
+	assert.Equal(t, int64(0), sketch.N())
 	assert.True(t, sketch.IsEmpty())
 }
 
@@ -40,10 +40,10 @@ func TestReservoirItemsSketchWithStrings(t *testing.T) {
 	sketch.Update("banana")
 	sketch.Update("cherry")
 
-	assert.Equal(t, int64(3), sketch.GetN())
-	assert.Equal(t, 3, sketch.GetNumSamples())
+	assert.Equal(t, int64(3), sketch.N())
+	assert.Equal(t, 3, sketch.NumSamples())
 
-	samples := sketch.GetSamples()
+	samples := sketch.Samples()
 	assert.Contains(t, samples, "apple")
 	assert.Contains(t, samples, "banana")
 	assert.Contains(t, samples, "cherry")
@@ -62,8 +62,8 @@ func TestReservoirItemsSketchWithStruct(t *testing.T) {
 	sketch.Update(Event{2, "logout"})
 	sketch.Update(Event{3, "click"})
 
-	assert.Equal(t, int64(3), sketch.GetN())
-	samples := sketch.GetSamples()
+	assert.Equal(t, int64(3), sketch.N())
+	samples := sketch.Samples()
 	assert.Len(t, samples, 3)
 }
 
@@ -82,10 +82,10 @@ func TestReservoirItemsSketchUpdateBelowK(t *testing.T) {
 		sketch.Update(i)
 	}
 
-	assert.Equal(t, int64(5), sketch.GetN())
-	assert.Equal(t, 5, sketch.GetNumSamples())
+	assert.Equal(t, int64(5), sketch.N())
+	assert.Equal(t, 5, sketch.NumSamples())
 
-	samples := sketch.GetSamples()
+	samples := sketch.Samples()
 	for i := int64(1); i <= 5; i++ {
 		assert.Contains(t, samples, i)
 	}
@@ -98,8 +98,8 @@ func TestReservoirItemsSketchUpdateAboveK(t *testing.T) {
 		sketch.Update(i)
 	}
 
-	assert.Equal(t, int64(1000), sketch.GetN())
-	assert.Equal(t, 10, sketch.GetNumSamples())
+	assert.Equal(t, int64(1000), sketch.N())
+	assert.Equal(t, 10, sketch.NumSamples())
 }
 
 func TestReservoirItemsSketchReset(t *testing.T) {
@@ -111,8 +111,8 @@ func TestReservoirItemsSketchReset(t *testing.T) {
 
 	sketch.Reset()
 	assert.True(t, sketch.IsEmpty())
-	assert.Equal(t, int64(0), sketch.GetN())
-	assert.Equal(t, 10, sketch.GetK())
+	assert.Equal(t, int64(0), sketch.N())
+	assert.Equal(t, 10, sketch.K())
 }
 
 func TestReservoirItemsUnion(t *testing.T) {
@@ -132,9 +132,9 @@ func TestReservoirItemsUnion(t *testing.T) {
 	union.UpdateSketch(sketch1)
 	union.UpdateSketch(sketch2)
 
-	result, err := union.GetResult()
+	result, err := union.Result()
 	assert.NoError(t, err)
-	assert.Equal(t, 10, result.GetNumSamples())
+	assert.Equal(t, 10, result.NumSamples())
 }
 
 func TestReservoirItemsUnionWithStrings(t *testing.T) {
@@ -153,8 +153,8 @@ func TestReservoirItemsUnionWithStrings(t *testing.T) {
 	union.UpdateSketch(sketch1)
 	union.UpdateSketch(sketch2)
 
-	result, _ := union.GetResult()
-	assert.LessOrEqual(t, result.GetNumSamples(), 5)
+	result, _ := union.Result()
+	assert.LessOrEqual(t, result.NumSamples(), 5)
 }
 
 func TestReservoirItemsSketchKEqualsOne(t *testing.T) {
@@ -166,16 +166,16 @@ func TestReservoirItemsSketchKEqualsOne(t *testing.T) {
 		sketch.Update(i)
 	}
 
-	assert.Equal(t, 1, sketch.GetNumSamples())
-	assert.Equal(t, int64(100), sketch.GetN())
+	assert.Equal(t, 1, sketch.NumSamples())
+	assert.Equal(t, int64(100), sketch.N())
 }
 
 func TestReservoirItemsSketchGetSamplesIsCopy(t *testing.T) {
 	sketch, _ := NewReservoirItemsSketch[int64](10)
 	sketch.Update(42)
 
-	samples1 := sketch.GetSamples()
-	samples2 := sketch.GetSamples()
+	samples1 := sketch.Samples()
+	samples2 := sketch.Samples()
 
 	// Modify samples1
 	samples1[0] = 999
@@ -197,8 +197,8 @@ func TestReservoirItemsUnionWithEmptySketch(t *testing.T) {
 	union.UpdateSketch(sketch1)
 	union.UpdateSketch(emptySketch) // Should not affect result
 
-	result, _ := union.GetResult()
-	assert.Equal(t, 5, result.GetNumSamples())
+	result, _ := union.Result()
+	assert.Equal(t, 5, result.NumSamples())
 }
 
 func TestReservoirItemsUnionWithNilSketch(t *testing.T) {
@@ -206,6 +206,6 @@ func TestReservoirItemsUnionWithNilSketch(t *testing.T) {
 	union.Update(42)
 	union.UpdateSketch(nil) // Should not panic
 
-	result, _ := union.GetResult()
-	assert.Equal(t, 1, result.GetNumSamples())
+	result, _ := union.Result()
+	assert.Equal(t, 1, result.NumSamples())
 }

--- a/sampling/reservoir_items_union.go
+++ b/sampling/reservoir_items_union.go
@@ -58,8 +58,8 @@ func (u *ReservoirItemsUnion[T]) UpdateSketch(sketch *ReservoirItemsSketch[T]) {
 		return
 	}
 
-	samples := sketch.GetSamples()
-	srcN := sketch.GetN()
+	samples := sketch.Samples()
+	srcN := sketch.N()
 
 	if u.gadget.IsEmpty() {
 		// If gadget is empty, copy the source directly
@@ -71,13 +71,13 @@ func (u *ReservoirItemsUnion[T]) UpdateSketch(sketch *ReservoirItemsSketch[T]) {
 	}
 
 	// Merge using weighted sampling
-	gadgetN := u.gadget.GetN()
+	gadgetN := u.gadget.N()
 	totalN := gadgetN + srcN
-	gadgetK := u.gadget.GetNumSamples()
+	gadgetK := u.gadget.NumSamples()
 	targetK := u.maxK
 
 	for _, item := range samples {
-		if u.gadget.GetNumSamples() < targetK {
+		if u.gadget.NumSamples() < targetK {
 			u.gadget.data = append(u.gadget.data, item)
 		} else {
 			j := rand.Int63n(totalN)
@@ -90,8 +90,8 @@ func (u *ReservoirItemsUnion[T]) UpdateSketch(sketch *ReservoirItemsSketch[T]) {
 	u.gadget.n = totalN
 }
 
-// GetResult returns a copy of the internal sketch.
-func (u *ReservoirItemsUnion[T]) GetResult() (*ReservoirItemsSketch[T], error) {
+// Result returns a copy of the internal sketch.
+func (u *ReservoirItemsUnion[T]) Result() (*ReservoirItemsSketch[T], error) {
 	result, err := NewReservoirItemsSketch[T](u.maxK)
 	if err != nil {
 		return nil, err
@@ -105,8 +105,8 @@ func (u *ReservoirItemsUnion[T]) GetResult() (*ReservoirItemsSketch[T], error) {
 	return result, nil
 }
 
-// GetMaxK returns the maximum k for this union.
-func (u *ReservoirItemsUnion[T]) GetMaxK() int {
+// MaxK returns the maximum k for this union.
+func (u *ReservoirItemsUnion[T]) MaxK() int {
 	return u.maxK
 }
 


### PR DESCRIPTION
## Summary

Implements `ReservoirItemsSketch[T any]` - a generic reservoir sampling sketch for the Go library. This addresses the ❌ status for sampling sketches in the README.

## Related Issue

#90 

## Implementation

### Files Added

| File | Description |
|------|-------------|
| `sampling/reservoir_items_sketch.go` | Generic reservoir sampling implementation |
| `sampling/reservoir_items_union.go` | Union for merging multiple sketches |
| `sampling/reservoir_items_sketch_test.go` | 13 unit tests |
| `examples/reservoir_example_test.go` | Usage examples with int64, string, struct |

### Algorithm

Classic Reservoir Sampling (Vitter's Algorithm R):
- **Initial phase** (n < k): all items are stored
- **Steady state** (n ≥ k): each new item replaces a random item with probability k/n

### API

```go
// Create sketch with capacity k
sketch, _ := sampling.NewReservoirItemsSketch[int64](10)

// Add items
sketch.Update(42)

// Get uniform random sample
samples := sketch.GetSamples()
```

## Notes

- **Generic implementation**: Works with any type (`int64`, `string`, custom structs)
- **Serialization**: Not included in this PR due to complexity of generic type serialization
- **Thread safety**: Not thread-safe; external synchronization required for concurrent use
- **ResizeFactor**: Kept for API compatibility with Java, but Go's slice append handles resizing

## Testing

All tests pass:
```
go test ./sampling/ ./examples/
ok      github.com/apache/datasketches-go/sampling
ok      github.com/apache/datasketches-go/examples
```
