### PR TITLE
refactor: clean theta encoder

### DIFF
--- a/theta/decoder.go
+++ b/theta/decoder.go
@@ -38,7 +38,7 @@ func NewDecoder(seed uint64) Decoder {
 }
 
 // Decode decodes a compact sketch from the given reader.
-func (dec Decoder) Decode(r io.Reader) (*CompactSketch, error) {
+func (dec *Decoder) Decode(r io.Reader) (*CompactSketch, error) {
 	bytes, err := io.ReadAll(r)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
I found that encoding v4 logic bit more simpler. so i clean little bit.

And Encoder, Decoder uses value receiver. No difference logic, but pointer receiver uses tiny less memory. because current value receiver uses 24Bytes(16bytes for pointer, 1byte for bool, 7bytes for padding) 