### PR TITLE
refactor: move theta sketch type into internal enum

### DIFF
--- a/internal/family.go
+++ b/internal/family.go
@@ -30,6 +30,7 @@ type families struct {
 	CountMinSketch family
 	BloomFilter    family
 	Tuple          family
+	Theta          family
 }
 
 var FamilyEnum = &families{
@@ -59,6 +60,10 @@ var FamilyEnum = &families{
 	},
 	Tuple: family{
 		Id:          9,
+		MaxPreLongs: 3,
+	},
+	Theta: family{
+		Id:          3,
 		MaxPreLongs: 3,
 	},
 }

--- a/theta/compact_sketch.go
+++ b/theta/compact_sketch.go
@@ -33,8 +33,6 @@ const UncompressedSerialVersion = 3
 
 const CompressedSerialVersion = 4
 
-const CompactSketchType = 3
-
 // Offsets in sizeof(type)
 const (
 	compactSketchPreLongsByte          = 0

--- a/theta/decoder.go
+++ b/theta/decoder.go
@@ -125,8 +125,8 @@ func decodeCompactSketch(bytes []byte, seed uint64) (compactSketchData, error) {
 		return compactSketchData{}, err
 	}
 
-	if bytes[compactSketchTypeByte] != CompactSketchType {
-		return compactSketchData{}, fmt.Errorf("invalid sketch type: expected %d, got %d", CompactSketchType, bytes[compactSketchTypeByte])
+	if bytes[compactSketchTypeByte] != uint8(internal.FamilyEnum.Theta.Id) {
+		return compactSketchData{}, fmt.Errorf("invalid sketch type: expected %d, got %d", internal.FamilyEnum.Theta.Id, bytes[compactSketchTypeByte])
 	}
 
 	serialVersion := bytes[compactSketchSerialVersionByte]

--- a/theta/encoder.go
+++ b/theta/encoder.go
@@ -20,6 +20,8 @@ package theta
 import (
 	"encoding/binary"
 	"io"
+
+	"github.com/apache/datasketches-go/internal"
 )
 
 // Encoder encodes a compact theta sketch to bytes.
@@ -73,7 +75,7 @@ func (enc *Encoder) encodeVersion4(sketch *CompactSketch, bytes []byte, offset i
 	offset++
 	bytes[offset] = CompressedSerialVersion
 	offset++
-	bytes[offset] = CompactSketchType
+	bytes[offset] = uint8(internal.FamilyEnum.Theta.Id)
 	offset++
 	bytes[offset] = entryBits
 	offset++
@@ -160,7 +162,7 @@ func (enc *Encoder) encodeSketch(sketch *CompactSketch, bytes []byte, offset int
 	offset++
 	bytes[offset] = UncompressedSerialVersion
 	offset++
-	bytes[offset] = CompactSketchType
+	bytes[offset] = uint8(internal.FamilyEnum.Theta.Id)
 	offset++
 
 	// 2 bytes unused

--- a/theta/sketch_serialization_test.go
+++ b/theta/sketch_serialization_test.go
@@ -898,7 +898,7 @@ func TestDecoderErrors(t *testing.T) {
 		invalidData := make([]byte, 8)
 		invalidData[0] = 1  // preamble longs
 		invalidData[1] = 99 // Invalid version
-		invalidData[2] = CompactSketchType
+		invalidData[2] = uint8(internal.FamilyEnum.Theta.Id)
 
 		decoder := NewDecoder(DefaultSeed)
 		_, err := decoder.Decode(bytes.NewReader(invalidData))


### PR DESCRIPTION
previous comment: https://github.com/apache/datasketches-go/pull/89#issuecomment-3715285828

Technically speaking, it is breaking change. But not released yet so It's worth taking to move into internal.