### PR TITLE
perf: reducing allocations in copy

### DIFF
--- a/cpc/cpc_sketch.go
+++ b/cpc/cpc_sketch.go
@@ -287,7 +287,7 @@ func (c *CpcSketch) updateWindowed(rowCol int) error {
 	}
 
 	isNovel := false //novel if new coupon
-	err := error(nil)
+	var err error
 	col := rowCol & 63
 
 	if col < c.windowOffset { // track the surprising 0's "before" the window

--- a/cpc/pair_table.go
+++ b/cpc/pair_table.go
@@ -263,7 +263,6 @@ func (p *pairTable) copy() (*pairTable, error) {
 	// copy the number of pairs.
 	newPT.numPairs = p.numPairs
 	// Deep copy the slots array.
-	newPT.slotsArr = make([]int, len(p.slotsArr))
 	copy(newPT.slotsArr, p.slotsArr)
 	return newPT, nil
 }


### PR DESCRIPTION
Already allocating in new slice in L258, so allocating again is useless.