### PR TITLE
refactor: strict validation from bytes for bloom filter

### DIFF
--- a/filters/bloom_filter_builder.go
+++ b/filters/bloom_filter_builder.go
@@ -22,6 +22,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"math"
+	"math/bits"
 
 	"github.com/apache/datasketches-go/internal"
 )
@@ -245,26 +246,23 @@ func NewBloomFilterFromSlice(bytes []byte) (BloomFilter, error) {
 		return nil, fmt.Errorf("non-empty filter size mismatch: got %d bytes, expected %d", len(bytes), expectedSize)
 	}
 
-	// Extract num bits set
-	numBitsSet := extractNumBitsSet(bytes)
-	if numBitsSet == dirtyBitsValue {
-		// Need to recount
-		bf.isDirty = true
-	} else {
-		bf.numBitsSet = numBitsSet
-	}
-
-	// Read bit array
+	// Read the bit array and compute its population count so the cached count in
+	// the serialized image can be validated.
+	actualNumBitsSet := uint64(0)
 	for i := 0; i < int(bitArrayLength); i++ {
 		offset := bitArrayOffset + i*8
-		bf.bitArray[i] = binary.LittleEndian.Uint64(bytes[offset:])
+		word := binary.LittleEndian.Uint64(bytes[offset:])
+		bf.bitArray[i] = word
+		actualNumBitsSet += uint64(bits.OnesCount64(word))
 	}
 
-	// Recount if dirty
-	if bf.isDirty {
-		bf.numBitsSet = countBitsSet(bf.bitArray)
-		bf.isDirty = false
+	// A dirty count is a request to recompute it. Any other cached count must
+	// agree with the decoded bit array.
+	numBitsSet := extractNumBitsSet(bytes)
+	if numBitsSet != dirtyBitsValue && numBitsSet != actualNumBitsSet {
+		return nil, fmt.Errorf("numBitsSet mismatch: serialized count %d, actual count %d", numBitsSet, actualNumBitsSet)
 	}
+	bf.numBitsSet = actualNumBitsSet
 
 	return bf, nil
 }

--- a/filters/bloom_filter_test.go
+++ b/filters/bloom_filter_test.go
@@ -498,6 +498,39 @@ func TestDeserializeInvalidData(t *testing.T) {
 	assert.Contains(t, err.Error(), "numHashes must be positive")
 }
 
+func TestDeserializeRejectsMismatchedNumBitsSet(t *testing.T) {
+	bf, err := NewBloomFilterBySize(256, 5, WithSeed(777))
+	assert.NoError(t, err)
+
+	for i := uint64(0); i < 50; i++ {
+		bf.UpdateUInt64(i)
+	}
+
+	serialized, err := bf.ToCompactSlice()
+	assert.NoError(t, err)
+	actualNumBitsSet := bf.BitsUsed()
+	assert.Greater(t, actualNumBitsSet, uint64(1))
+
+	testCases := []struct {
+		name             string
+		cachedNumBitsSet uint64
+	}{
+		{name: "zero count", cachedNumBitsSet: 0},
+		{name: "undercount", cachedNumBitsSet: actualNumBitsSet - 1},
+		{name: "overcount", cachedNumBitsSet: actualNumBitsSet + 1},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			corrupt := append([]byte(nil), serialized...)
+			insertNumBitsSet(corrupt, tc.cachedNumBitsSet)
+
+			_, err := NewBloomFilterFromSlice(corrupt)
+			assert.ErrorContains(t, err, "numBitsSet mismatch")
+		})
+	}
+}
+
 func TestDeserializeWithDirtyBits(t *testing.T) {
 	// Create and populate a filter
 	bf1, err := NewBloomFilterBySize(256, 5, WithSeed(777))
@@ -521,6 +554,9 @@ func TestDeserializeWithDirtyBits(t *testing.T) {
 	// Should have correct bit count (recalculated)
 	assert.Equal(t, bf1.BitsUsed(), bf2.BitsUsed())
 	assert.Greater(t, bf2.BitsUsed(), uint64(0))
+	for i := uint64(0); i < 50; i++ {
+		assert.True(t, bf2.QueryUInt64(i), "Item %d should be found after dirty-count deserialization", i)
+	}
 }
 
 func TestSerializeDeserializeConsistency(t *testing.T) {


### PR DESCRIPTION
Following Rust implementation, see this: https://github.com/apache/datasketches-rust/pull/190

Adding more strict validation from invalid serialized sketch makes sense here.