### PR TITLE
perf: reduce allocation in serializing for frequency sketch

### DIFF
--- a/frequencies/items_sketch.go
+++ b/frequencies/items_sketch.go
@@ -471,14 +471,18 @@ func (i *ItemsSketch[C]) ToSlice() ([]byte, error) {
 		preArr := make([]int64, preLongs)
 		preArr[0] = pre0
 		preArr[1] = insertActiveItems(int64(activeItems), pre)
-		preArr[2] = int64(i.streamWeight)
-		preArr[3] = int64(i.offset)
+		preArr[2] = i.streamWeight
+		preArr[3] = i.offset
 		for j := 0; j < preLongs; j++ {
 			binary.LittleEndian.PutUint64(outArr[j<<3:], uint64(preArr[j]))
 		}
 		preBytes := preLongs << 3
-		for j := 0; j < activeItems; j++ {
-			binary.LittleEndian.PutUint64(outArr[preBytes+j<<3:], uint64(i.hashMap.getActiveValues()[j]))
+		activeIndex := 0
+		for slot, state := range i.hashMap.states {
+			if state > 0 {
+				binary.LittleEndian.PutUint64(outArr[preBytes+(activeIndex<<3):], uint64(i.hashMap.values[slot]))
+				activeIndex++
+			}
 		}
 		copy(outArr[preBytes+(activeItems<<3):], bytes)
 	}

--- a/frequencies/items_sketch_test.go
+++ b/frequencies/items_sketch_test.go
@@ -262,6 +262,66 @@ func TestSerializeDeserializeLong(t *testing.T) {
 	assert.Equal(t, est, int64(1))
 }
 
+func TestItemsSketchToSlicePreservesValueOrder(t *testing.T) {
+	t.Run("int64", func(t *testing.T) {
+		testItemsSketchToSlicePreservesValueOrder(
+			t,
+			common.ItemSketchLongHasher{},
+			common.ItemSketchLongSerDe{},
+			func(index int) int64 { return int64(index) },
+		)
+	})
+	t.Run("string", func(t *testing.T) {
+		testItemsSketchToSlicePreservesValueOrder(
+			t,
+			common.ItemSketchStringHasher{},
+			common.ItemSketchStringSerDe{},
+			func(index int) string { return "item-" + strconv.Itoa(index) },
+		)
+	})
+}
+
+func testItemsSketchToSlicePreservesValueOrder[C comparable](
+	t *testing.T,
+	hasher common.ItemSketchHasher[C],
+	serde common.ItemSketchSerde[C],
+	itemAt func(int) C,
+) {
+	const (
+		mapSize     = 64
+		activeItems = mapSize * 3 / 4
+	)
+
+	sketch, err := NewFrequencyItemsSketchWithMaxMapSize(mapSize, hasher, serde)
+	if !assert.NoError(t, err) {
+		return
+	}
+	for index := 0; index < activeItems; index++ {
+		err = sketch.UpdateMany(itemAt(index), int64(index+1))
+		if !assert.NoError(t, err) {
+			return
+		}
+	}
+
+	serialized, err := sketch.ToSlice()
+	if !assert.NoError(t, err) {
+		return
+	}
+	restored, err := NewFrequencyItemsSketchFromSlice(serialized, hasher, serde)
+	if !assert.NoError(t, err) {
+		return
+	}
+
+	assert.Equal(t, sketch.GetNumActiveItems(), restored.GetNumActiveItems())
+	assert.Equal(t, sketch.GetStreamLength(), restored.GetStreamLength())
+	assert.Equal(t, sketch.GetMaximumError(), restored.GetMaximumError())
+	for index := 0; index < activeItems; index++ {
+		actual, err := restored.GetLowerBound(itemAt(index))
+		assert.NoError(t, err)
+		assert.Equal(t, int64(index+1), actual)
+	}
+}
+
 func TestResize(t *testing.T) {
 	sketch1, err := NewFrequencyItemsSketchWithMaxMapSize[string](2<<_LG_MIN_MAP_SIZE, common.ItemSketchStringHasher{}, nil)
 	for i := 0; i < 32; i++ {
@@ -310,11 +370,10 @@ func TestMergeExact(t *testing.T) {
 	assert.Equal(t, est, int64(1))
 }
 
-func TestNullMapReturns(t *testing.T) {
+func TestEmptyMapReturnsNilActiveKeys(t *testing.T) {
 	map1, err := newReversePurgeItemHashMap[int64](1<<_LG_MIN_MAP_SIZE, common.ItemSketchLongHasher{}, nil)
 	assert.NoError(t, err)
 	assert.Nil(t, map1.getActiveKeys())
-	assert.Nil(t, map1.getActiveValues())
 }
 
 func TestMisc(t *testing.T) {
@@ -489,6 +548,65 @@ func BenchmarkItemSketch(b *testing.B) {
 	assert.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		sketch.Update(int64(i))
+	}
+}
+
+var benchmarkItemsSketchToSliceSink []byte
+
+func BenchmarkItemsSketchToSlice(b *testing.B) {
+	benchmarkItemsSketchToSlice(
+		b,
+		"int64",
+		common.ItemSketchLongHasher{},
+		common.ItemSketchLongSerDe{},
+		func(index int) int64 { return int64(index) },
+	)
+	benchmarkItemsSketchToSlice(
+		b,
+		"string",
+		common.ItemSketchStringHasher{},
+		common.ItemSketchStringSerDe{},
+		func(index int) string { return "item-" + strconv.Itoa(index) },
+	)
+}
+
+func benchmarkItemsSketchToSlice[C comparable](
+	b *testing.B,
+	itemType string,
+	hasher common.ItemSketchHasher[C],
+	serde common.ItemSketchSerde[C],
+	itemAt func(int) C,
+) {
+	for _, mapSize := range []int{64, 256, 1024} {
+		activeItems := mapSize * 3 / 4
+		b.Run(itemType+"/items="+strconv.Itoa(activeItems), func(b *testing.B) {
+			sketch, err := NewFrequencyItemsSketchWithMaxMapSize(mapSize, hasher, serde)
+			if err != nil {
+				b.Fatal(err)
+			}
+			for index := 0; index < activeItems; index++ {
+				if err := sketch.UpdateMany(itemAt(index), int64(index+1)); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			serialized, err := sketch.ToSlice()
+			if err != nil {
+				b.Fatal(err)
+			}
+			benchmarkItemsSketchToSliceSink = serialized
+			b.SetBytes(int64(len(serialized)))
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for iteration := 0; iteration < b.N; iteration++ {
+				serialized, err = sketch.ToSlice()
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkItemsSketchToSliceSink = serialized
+			}
+		})
 	}
 }
 

--- a/frequencies/reverse_purge_item_hash_map.go
+++ b/frequencies/reverse_purge_item_hash_map.go
@@ -249,19 +249,6 @@ func (r *reversePurgeItemHashMap[C]) hashDelete(deleteProbe int) {
 	}
 }
 
-func (r *reversePurgeItemHashMap[C]) getActiveValues() []int64 {
-	if r.numActive == 0 {
-		return nil
-	}
-	returnValues := make([]int64, 0, r.numActive)
-	for i := 0; i < len(r.values); i++ {
-		if r.states[i] > 0 { //isActive
-			returnValues = append(returnValues, r.values[i])
-		}
-	}
-	return returnValues
-}
-
 func (r *reversePurgeItemHashMap[C]) getActiveKeys() []C {
 	if r.numActive == 0 {
 		return nil


### PR DESCRIPTION
During serialization, current implementation allocates same active items multiple times. It makes huge overhead because of heap allocation.

See the benchmark:

Current main branch:

```
goos: darwin
goarch: arm64
pkg: github.com/apache/datasketches-go/frequencies
cpu: Apple M1 Pro
BenchmarkItemsSketchToSlice
BenchmarkItemsSketchToSlice/int64/items=48
BenchmarkItemsSketchToSlice/int64/items=48-10         	  208099	      6027 ns/op	 132.73 MB/s	   20096 B/op	      51 allocs/op
BenchmarkItemsSketchToSlice/int64/items=192
BenchmarkItemsSketchToSlice/int64/items=192-10        	   14924	     80697 ns/op	  38.46 MB/s	  301185 B/op	     195 allocs/op
BenchmarkItemsSketchToSlice/int64/items=768
BenchmarkItemsSketchToSlice/int64/items=768-10        	    1072	   1082348 ns/op	  11.38 MB/s	 4744468 B/op	     771 allocs/op
BenchmarkItemsSketchToSlice/string/items=48
BenchmarkItemsSketchToSlice/string/items=48-10        	  200163	      5586 ns/op	 167.22 MB/s	   20928 B/op	      51 allocs/op
BenchmarkItemsSketchToSlice/string/items=192
BenchmarkItemsSketchToSlice/string/items=192-10       	   15355	     75696 ns/op	  49.70 MB/s	  304512 B/op	     195 allocs/op
BenchmarkItemsSketchToSlice/string/items=768
BenchmarkItemsSketchToSlice/string/items=768-10       	    1129	   1072233 ns/op	  14.25 MB/s	 4758036 B/op	     771 allocs/op
```


Change:

```
goos: darwin
goarch: arm64
pkg: github.com/apache/datasketches-go/frequencies
cpu: Apple M1 Pro
BenchmarkItemsSketchToSlice
BenchmarkItemsSketchToSlice/int64/items=48
BenchmarkItemsSketchToSlice/int64/items=48-10         	 2943316	       401.4 ns/op	1992.87 MB/s	    1664 B/op	       3 allocs/op
BenchmarkItemsSketchToSlice/int64/items=192
BenchmarkItemsSketchToSlice/int64/items=192-10        	  865233	      1399 ns/op	2218.19 MB/s	    6272 B/op	       3 allocs/op
BenchmarkItemsSketchToSlice/int64/items=768
BenchmarkItemsSketchToSlice/int64/items=768-10        	  211227	      5016 ns/op	2456.31 MB/s	   25856 B/op	       3 allocs/op
BenchmarkItemsSketchToSlice/string/items=48
BenchmarkItemsSketchToSlice/string/items=48-10        	 2000376	       599.6 ns/op	1557.73 MB/s	    2496 B/op	       3 allocs/op
BenchmarkItemsSketchToSlice/string/items=192
BenchmarkItemsSketchToSlice/string/items=192-10       	  575967	      2041 ns/op	1843.51 MB/s	    9600 B/op	       3 allocs/op
BenchmarkItemsSketchToSlice/string/items=768
BenchmarkItemsSketchToSlice/string/items=768-10       	  145569	      9110 ns/op	1677.53 MB/s	   39424 B/op	       3 allocs/op
PASS
```