### PR TITLE
fix: REQ sketch loses min/max when merging into a new sketch

### DIFF
--- a/req/sketch.go
+++ b/req/sketch.go
@@ -77,6 +77,8 @@ func NewSketch(options ...SketchOptionFunc) (*Sketch, error) {
 	sk := &Sketch{
 		k:                      defaultK,
 		isHighRankAccuracyMode: true,
+		minItem:                float32(math.NaN()),
+		maxItem:                float32(math.NaN()),
 	}
 	for _, option := range options {
 		option(sk)

--- a/req/sketch_test.go
+++ b/req/sketch_test.go
@@ -1002,3 +1002,141 @@ func TestSketchQuantileBounds(t *testing.T) {
 		assert.LessOrEqual(t, qlb, qub)
 	})
 }
+
+func TestSketchMergeIntoEmptyMinMax(t *testing.T) {
+	newLoaded := func(t *testing.T, from, to int) *Sketch {
+		t.Helper()
+		sk, err := NewSketch()
+		assert.NoError(t, err)
+		for i := from; i <= to; i++ {
+			assert.NoError(t, sk.Update(float32(i)))
+		}
+		return sk
+	}
+
+	t.Run("all items above zero", func(t *testing.T) {
+		src := newLoaded(t, 10, 30)
+		dst, err := NewSketch()
+		assert.NoError(t, err)
+		assert.NoError(t, dst.Merge(src))
+
+		minV, err := dst.MinItem()
+		assert.NoError(t, err)
+		assert.Equal(t, float32(10), minV)
+
+		maxV, err := dst.MaxItem()
+		assert.NoError(t, err)
+		assert.Equal(t, float32(30), maxV)
+	})
+
+	t.Run("all items below zero", func(t *testing.T) {
+		src := newLoaded(t, -30, -10)
+		dst, err := NewSketch()
+		assert.NoError(t, err)
+		assert.NoError(t, dst.Merge(src))
+
+		minV, err := dst.MinItem()
+		assert.NoError(t, err)
+		assert.Equal(t, float32(-30), minV)
+
+		maxV, err := dst.MaxItem()
+		assert.NoError(t, err)
+		assert.Equal(t, float32(-10), maxV)
+	})
+
+	t.Run("single item", func(t *testing.T) {
+		src := newLoaded(t, 42, 42)
+		dst, err := NewSketch()
+		assert.NoError(t, err)
+		assert.NoError(t, dst.Merge(src))
+
+		minV, err := dst.MinItem()
+		assert.NoError(t, err)
+		assert.Equal(t, float32(42), minV)
+
+		maxV, err := dst.MaxItem()
+		assert.NoError(t, err)
+		assert.Equal(t, float32(42), maxV)
+	})
+
+	t.Run("new sketch matches reset sketch", func(t *testing.T) {
+		src := newLoaded(t, 10, 30)
+
+		fresh, err := NewSketch()
+		assert.NoError(t, err)
+		assert.NoError(t, fresh.Merge(src))
+
+		reset, err := NewSketch()
+		assert.NoError(t, err)
+		reset.Reset()
+		assert.NoError(t, reset.Merge(src))
+
+		freshMin, err := fresh.MinItem()
+		assert.NoError(t, err)
+		resetMin, err := reset.MinItem()
+		assert.NoError(t, err)
+		assert.Equal(t, resetMin, freshMin)
+
+		freshMax, err := fresh.MaxItem()
+		assert.NoError(t, err)
+		resetMax, err := reset.MaxItem()
+		assert.NoError(t, err)
+		assert.Equal(t, resetMax, freshMax)
+	})
+
+	t.Run("chained merges", func(t *testing.T) {
+		dst, err := NewSketch()
+		assert.NoError(t, err)
+		for i := 0; i < 4; i++ {
+			assert.NoError(t, dst.Merge(newLoaded(t, 1000+i*500, 1000+i*500+499)))
+		}
+		assert.Equal(t, int64(2000), dst.N())
+
+		minV, err := dst.MinItem()
+		assert.NoError(t, err)
+		assert.Equal(t, float32(1000), minV)
+
+		maxV, err := dst.MaxItem()
+		assert.NoError(t, err)
+		assert.Equal(t, float32(2999), maxV)
+	})
+
+	t.Run("estimates", func(t *testing.T) {
+		src := newLoaded(t, 1001, 1100)
+		dst, err := NewSketch()
+		assert.NoError(t, err)
+		assert.NoError(t, dst.Merge(src))
+
+		q, err := dst.Quantile(0)
+		assert.NoError(t, err)
+		assert.Equal(t, float32(1001), q)
+
+		r, err := dst.Rank(500)
+		assert.NoError(t, err)
+		assert.Equal(t, float64(0), r)
+
+		sv, err := dst.SortedView()
+		assert.NoError(t, err)
+		assert.Equal(t, float32(1001), sv.Quantiles()[0])
+	})
+
+	t.Run("survives serialization", func(t *testing.T) {
+		src := newLoaded(t, 1001, 6000)
+		dst, err := NewSketch()
+		assert.NoError(t, err)
+		assert.NoError(t, dst.Merge(src))
+
+		b, err := dst.MarshalBinary()
+		assert.NoError(t, err)
+		decoded, err := Decode(b)
+		assert.NoError(t, err)
+
+		minV, err := decoded.MinItem()
+		assert.NoError(t, err)
+		assert.Equal(t, float32(1001), minV)
+
+		maxV, err := decoded.MaxItem()
+		assert.NoError(t, err)
+		assert.Equal(t, float32(6000), maxV)
+	})
+}


### PR DESCRIPTION
`req.NewSketch()` leaves `minItem`/`maxItem` at Go's zero value, but `Merge` and `Reset` both use NaN as the "unset" sentinel. So merging into a freshly created sketch computes `min(0, other.minItem)` and `max(0, other.maxItem)`, and the 0 wins whenever the stream doesn't straddle it.

```go
src, _ := req.NewSketch()
for i := 1001; i <= 1100; i++ { src.Update(float32(i)) }

dst, _ := req.NewSketch()
dst.Merge(src)

dst.MinItem()   // 0, want 1001
dst.Quantile(0) // 0, want 1001
dst.Rank(500)   // 0.01, want 0
```

It's not just the getters. The bogus 0 is reinserted into the sorted view as a retained quantile, so `Quantile`, `Rank`, `CDF` and `PMF` all shift, and it survives `MarshalBinary` + `Decode`. Chained merges into an empty accumulator, which is the usual map-reduce shape, hit it too. `NewSketch()` then `Reset()` then `Merge` works fine, which is the tell.

`ReqSketch.java` initialises the fields at declaration:

```java
private float minItem = Float.NaN;
private float maxItem = Float.NaN;
```

Go has no field initialisers so the port dropped it. I set them in `NewSketch` instead. That covers every construction site: the decoder's empty and raw-items paths both go through `NewSketch`, and the exact and estimation paths read min/max out of the buffer. `Update` guards on `IsEmpty()` so it was never affected, and every reader of the fields (`MinItem`, `MaxItem`, `refreshSortedView`, the estimation-format encoder) is already behind an emptiness check, so no path can now observe the NaN.

How I found it: I built an invariant harness over the quantile families asserting that min/max after merging into a fresh sketch equals min/max after merging into a reset sketch, and equals the source's. 5 value patterns across REQ, KLL and t-digest. KLL and t-digest are clean; REQ fails 4 of 5. The one that passes is the case whose data straddles zero, which is why the existing `Merge Multiple` test misses it. I checked the intended semantics against `ReqSketch.java` rather than guessing at it. The same harness also ran 200-trial randomised sweeps per family for quantile monotonicity in rank, CDF within [0,1] and non-decreasing, PMF summing to 1, and serialize/deserialize identity; nothing else came out of it, and I confirmed `tdigest.Quantile` matches `tdigest_impl.hpp` line for line.

7 subtests added in `TestSketchMergeIntoEmptyMinMax`. All 7 fail on `main` with only the test file applied, all 7 pass with the two-line change. `make lint-check` and `go test -race ./req/` are clean and the full suite is green.

Written with AI assistance (Claude). I reviewed the change and ran everything above myself.
