### PR TITLE
Fix swapped interpolation weights and right tail sign in tdigest Quantile

### DIFF
--- a/tdigest/double.go
+++ b/tdigest/double.go
@@ -376,7 +376,7 @@ func (d *Double) Quantile(rank float64) (float64, error) {
 
 	lastWeight := float64(d.centroids[len(d.centroids)-1].weight)
 	if lastWeight > 1 && float64(d.centroidsWeight)-weight <= lastWeight/2.0 {
-		return d.max + (float64(d.centroidsWeight)-weight-1.0)/(lastWeight/2.0-1.0)*(d.max-d.centroids[len(d.centroids)-1].mean), nil
+		return d.max - (float64(d.centroidsWeight)-weight-1.0)/(lastWeight/2.0-1.0)*(d.max-d.centroids[len(d.centroids)-1].mean), nil
 	}
 
 	// interpolate between extremes
@@ -401,7 +401,7 @@ func (d *Double) Quantile(rank float64) (float64, error) {
 			}
 			w1 := weight - weightSoFar - leftWeight
 			w2 := weightSoFar + dw - weight - rightWeight
-			return weightedAverage(d.centroids[i].mean, w1, d.centroids[i+1].mean, w2), nil
+			return weightedAverage(d.centroids[i].mean, w2, d.centroids[i+1].mean, w1), nil
 		}
 		weightSoFar += dw
 	}

--- a/tdigest/double_test.go
+++ b/tdigest/double_test.go
@@ -19,6 +19,7 @@ package tdigest
 
 import (
 	"math"
+	"math/rand"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -1021,5 +1022,91 @@ func TestDouble_SerializedSizeBytes(t *testing.T) {
 		// Without buffer compresses first: preamble(16) + min/max(16) + centroids(16*100) = 1632
 		sizeWithoutBuffer := sk.SerializedSizeBytes(false)
 		assert.Equal(t, 1632, sizeWithoutBuffer)
+	})
+}
+
+func TestDouble_QuantileIsMonotonic(t *testing.T) {
+	distributions := map[string]func(r *rand.Rand) float64{
+		"gaussian":  func(r *rand.Rand) float64 { return r.NormFloat64() },
+		"uniform":   func(r *rand.Rand) float64 { return r.Float64() * 1000 },
+		"lognormal": func(r *rand.Rand) float64 { return math.Exp(r.NormFloat64()) },
+	}
+
+	for name, next := range distributions {
+		t.Run(name, func(t *testing.T) {
+			r := rand.New(rand.NewSource(1))
+			for _, k := range []uint16{10, 20, 50, 100, 200} {
+				for trial := 0; trial < 40; trial++ {
+					sketch, err := NewDouble(k)
+					assert.NoError(t, err)
+					n := 100 + r.Intn(50000)
+					for i := 0; i < n; i++ {
+						assert.NoError(t, sketch.Update(next(r)))
+					}
+
+					previousRank := 0.0
+					previousQuantile, err := sketch.Quantile(0)
+					assert.NoError(t, err)
+					for i := 1; i <= 1000; i++ {
+						rank := float64(i) / 1000.0
+						quantile, err := sketch.Quantile(rank)
+						assert.NoError(t, err)
+						assert.GreaterOrEqualf(t, quantile, previousQuantile,
+							"k=%d n=%d: Quantile(%v)=%v is below Quantile(%v)=%v",
+							k, n, rank, quantile, previousRank, previousQuantile)
+						previousRank = rank
+						previousQuantile = quantile
+					}
+				}
+			}
+		})
+	}
+}
+
+func TestDouble_QuantileIsWithinMinAndMax(t *testing.T) {
+	t.Run("From updates", func(t *testing.T) {
+		r := rand.New(rand.NewSource(2))
+		for trial := 0; trial < 100; trial++ {
+			sketch, err := NewDouble(DefaultK)
+			assert.NoError(t, err)
+			n := 10 + r.Intn(20000)
+			for i := 0; i < n; i++ {
+				assert.NoError(t, sketch.Update(r.NormFloat64()))
+			}
+			minValue, err := sketch.MinValue()
+			assert.NoError(t, err)
+			maxValue, err := sketch.MaxValue()
+			assert.NoError(t, err)
+			for i := 0; i <= 1000; i++ {
+				quantile, err := sketch.Quantile(float64(i) / 1000.0)
+				assert.NoError(t, err)
+				assert.GreaterOrEqual(t, quantile, minValue)
+				assert.LessOrEqual(t, quantile, maxValue)
+			}
+		}
+	})
+
+	// Update and Merge always leave both tail centroids as singletons, so the
+	// tail branches of Quantile are only reachable through deserialization.
+	t.Run("Decoded with heavy tail centroids", func(t *testing.T) {
+		sketch, err := newDoubleFromInternalStates(false, DefaultK, 0, 40,
+			[]doublePrecisionCentroid{{mean: 10, weight: 100}, {mean: 20, weight: 100}, {mean: 30, weight: 100}},
+			300, nil)
+		assert.NoError(t, err)
+		bytes, err := EncodeDouble(sketch, false)
+		assert.NoError(t, err)
+		decoded, err := DecodeDouble(bytes)
+		assert.NoError(t, err)
+
+		quantile, err := decoded.Quantile(0.9)
+		assert.NoError(t, err)
+		assert.InDelta(t, 34.081632653061224, quantile, 1e-12)
+
+		for i := 0; i <= 1000; i++ {
+			quantile, err := decoded.Quantile(float64(i) / 1000.0)
+			assert.NoError(t, err)
+			assert.GreaterOrEqual(t, quantile, 0.0)
+			assert.LessOrEqual(t, quantile, 40.0)
+		}
 	})
 }


### PR DESCRIPTION
Two spots in `tdigest.Double.Quantile` differ from the reference implementation ([MergingDigest](https://github.com/tdunning/t-digest/blob/main/core/src/main/java/com/tdunning/math/stats/MergingDigest.java)). The first affects ordinary use, the second needs a decoded sketch.

### The interpolation weights are passed in the wrong order

Reference:

```java
double z1 = index - weightSoFar - leftUnit;
double z2 = weightSoFar + dw - index - rightUnit;
return weightedAverage(mean[i], z2, mean[i + 1], z1);
```

We compute the same two quantities as `w1`/`w2` and then call `weightedAverage(d.centroids[i].mean, w1, d.centroids[i+1].mean, w2)`. The weight on `mean[i]` should be the distance to the far end of the bracket, not the near one. As the rank rises inside a bracket the estimate moves toward the lower centroid instead of the upper one.

That makes `Quantile` non-monotonic from a plain `Update` sequence. 2000 of 2000 random digests return some `Quantile(r2) < Quantile(r1)` with `r2 > r1`, k in {10, 20, 50, 100, 200}, n in [100, 50000], gaussian / uniform / lognormal. It also shows on the checked-in fixtures: `tdigest_ref_k100_n10000_double.sk` and every `serialization_test_data/cpp_generated_files/tdigest_double_*` file give thousands of descents over 5000 evenly spaced ranks, and 0 after.

It costs accuracy too. Rank error against the exact quantiles of the input, 29970 queries at k=100, n=20000 gaussian:

```
          mean       max
before    0.011803   0.042200
after     0.000385   0.002100
```

### The right tail branch adds where the reference subtracts

Reference is `max - (...)`, we have `d.max + (...)`, so the branch returns quantiles above `MaxValue()`. On min 0, centroids (10,100), (20,100), (30,100), max 40, rank 0.90 returns 45.92 where the reference gives 34.08.

This one is not reachable from `Update` or `Merge`. `merge` never lets the first or last centroid absorb a neighbour, so both tails stay singletons and `lastWeight > 1` is false. I looked for a counterexample over 3000 digests built from random updates, merges and encode/decode round trips and never saw a first or last centroid of weight above 1. It is reachable from `DecodeDouble`, which accepts one, so the test builds it that way.

`Rank`'s left tail already has the `/ centroidsWeight` normalizer, so there is nothing to change there. That is the one difference from apache/datasketches-java#755, which fixes the same two plus a missing normalizer in `getRank`.

Two new tests, each verified failing before its own fix with the tests kept in place. `go test ./...` and `go test -race ./tdigest/` are green before and after, so nothing existing covered this.

I used Claude Code on this. The oracles were tdunning's `MergingDigest` and monotonicity, which needs no second implementation. Differential testing against the C++ core would not have found it, since C++ has the same two.
