### PR TITLE
perf: reduce temp allocation in serialization

### DIFF
--- a/frequencies/longs_sketch.go
+++ b/frequencies/longs_sketch.go
@@ -520,15 +520,19 @@ func (s *LongsSketch) ToSlice() []byte {
 		binary.LittleEndian.PutUint64(outArr[i<<3:], uint64(preArr[i]))
 	}
 
+	// All active values are written first, then all active keys, both in table
+	// index order. The two regions are disjoint, so a single pass over the hash
+	// table fills both without any intermediate slices.
 	preBytes := preLongs << 3
-	activeValues := s.hashMap.getActiveValues()
-	for i := 0; i < activeItems; i++ {
-		binary.LittleEndian.PutUint64(outArr[preBytes+(i<<3):], uint64(activeValues[i]))
-	}
-
-	activeKeys := s.hashMap.getActiveKeys()
-	for i := 0; i < activeItems; i++ {
-		binary.LittleEndian.PutUint64(outArr[preBytes+((activeItems+i)<<3):], uint64(activeKeys[i]))
+	keysOffset := preBytes + (activeItems << 3)
+	hashMap := s.hashMap
+	j := 0
+	for i := 0; i < len(hashMap.states); i++ {
+		if hashMap.states[i] > 0 { //isActive
+			binary.LittleEndian.PutUint64(outArr[preBytes+(j<<3):], uint64(hashMap.values[i]))
+			binary.LittleEndian.PutUint64(outArr[keysOffset+(j<<3):], uint64(hashMap.keys[i]))
+			j++
+		}
 	}
 
 	return outArr

--- a/frequencies/longs_sketch_test.go
+++ b/frequencies/longs_sketch_test.go
@@ -23,8 +23,9 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/apache/datasketches-go/internal"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/datasketches-go/internal"
 )
 
 func TestFrequentItemsStringSerial(t *testing.T) {
@@ -642,5 +643,38 @@ func BenchmarkLongSketch(b *testing.B) {
 	assert.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		sketch.Update(int64(i))
+	}
+}
+
+var toSliceSink []byte
+
+func BenchmarkLongsSketchToSlice(b *testing.B) {
+	cases := []struct {
+		lgMaxMapSize int
+		numItems     int
+	}{
+		{6, 48},
+		{10, 768},
+		{14, 12288},
+		{18, 196608},
+	}
+
+	for _, c := range cases {
+		sk, err := NewLongsSketch(c.lgMaxMapSize, _LG_MIN_MAP_SIZE)
+		if err != nil {
+			b.Fatal(err)
+		}
+		for i := 0; i < c.numItems; i++ {
+			if err := sk.UpdateMany(int64(i), int64(i+1)); err != nil {
+				b.Fatal(err)
+			}
+		}
+
+		b.Run(fmt.Sprintf("active=%d", sk.GetNumActiveItems()), func(b *testing.B) {
+			b.ReportAllocs()
+			for b.Loop() {
+				toSliceSink = sk.ToSlice()
+			}
+		})
 	}
 }

--- a/frequencies/reverse_purge_long_hash_map.go
+++ b/frequencies/reverse_purge_long_hash_map.go
@@ -305,32 +305,6 @@ func deserializeFromStringArray(tokens []string) (*reversePurgeLongHashMap, erro
 	return hashMap, nil
 }
 
-func (r *reversePurgeLongHashMap) getActiveValues() []int64 {
-	if r.numActive == 0 {
-		return nil
-	}
-	returnValues := make([]int64, 0, r.numActive)
-	for i := 0; i < len(r.values); i++ {
-		if r.states[i] > 0 { //isActive
-			returnValues = append(returnValues, r.values[i])
-		}
-	}
-	return returnValues
-}
-
-func (r *reversePurgeLongHashMap) getActiveKeys() []int64 {
-	if r.numActive == 0 {
-		return nil
-	}
-	returnValues := make([]int64, 0, r.numActive)
-	for i := 0; i < len(r.keys); i++ {
-		if r.states[i] > 0 { //isActive
-			returnValues = append(returnValues, r.keys[i])
-		}
-	}
-	return returnValues
-}
-
 func (s *reversePurgeLongHashMap) iterator() *iteratorLongHashMap {
 	return newIteratorLong(s.keys, s.values, s.states, s.numActive)
 }


### PR DESCRIPTION
During Serialization, temporary allocations happens due to collecting active values and active keys.

But we can remove those allocations and reduce 4 loops to one.


main branch:

```
goos: darwin
goarch: arm64
pkg: github.com/apache/datasketches-go/frequencies
cpu: Apple M4 Pro
BenchmarkLongsSketchToSlice
BenchmarkLongsSketchToSlice/active=48
BenchmarkLongsSketchToSlice/active=48-12         	 4521978	       262.5 ns/op	    1664 B/op	       3 allocs/op
BenchmarkLongsSketchToSlice/active=768
BenchmarkLongsSketchToSlice/active=768-12        	  344616	      3540 ns/op	   25856 B/op	       3 allocs/op
BenchmarkLongsSketchToSlice/active=12288
BenchmarkLongsSketchToSlice/active=12288-12      	   20967	     56307 ns/op	  401410 B/op	       3 allocs/op
BenchmarkLongsSketchToSlice/active=196608
BenchmarkLongsSketchToSlice/active=196608-12     	    1006	   1112128 ns/op	 6299650 B/op	       3 allocs/op
PASS
```

This PR:
```
goos: darwin
goarch: arm64
pkg: github.com/apache/datasketches-go/frequencies
cpu: Apple M4 Pro
BenchmarkLongsSketchToSlice
BenchmarkLongsSketchToSlice/active=48
BenchmarkLongsSketchToSlice/active=48-12         	 9544124	       126.4 ns/op	     896 B/op	       1 allocs/op
BenchmarkLongsSketchToSlice/active=768
BenchmarkLongsSketchToSlice/active=768-12        	  701419	      1667 ns/op	   13568 B/op	       1 allocs/op
BenchmarkLongsSketchToSlice/active=12288
BenchmarkLongsSketchToSlice/active=12288-12      	   38566	     31243 ns/op	  204803 B/op	       1 allocs/op
BenchmarkLongsSketchToSlice/active=196608
BenchmarkLongsSketchToSlice/active=196608-12     	    2101	    559105 ns/op	 3153921 B/op	       1 allocs/op
PASS
```