### PR TITLE
perf: reduce temp allocation in deserialization

### DIFF
--- a/frequencies/items_sketch.go
+++ b/frequencies/items_sketch.go
@@ -115,6 +115,9 @@ func NewFrequencyItemsSketchFromSlice[C comparable](slc []byte, hasher common.It
 	}
 
 	pre0, err := checkPreambleSize(slc) //make sure preamble will fit
+	if err != nil {
+		return nil, err
+	}
 	maxPreLongs := internal.FamilyEnum.Frequency.MaxPreLongs
 
 	preLongs := extractPreLongs(pre0)                     //Byte 0
@@ -143,30 +146,20 @@ func NewFrequencyItemsSketchFromSlice[C comparable](slc []byte, hasher common.It
 	if empty {
 		return NewFrequencyItemsSketchWithMaxMapSize[C](1<<_LG_MIN_MAP_SIZE, hasher, serde)
 	}
-	// Get full preamble
-	preArr := make([]int64, preLongs)
-	for j := 0; j < preLongs; j++ {
-		preArr[j] = int64(binary.LittleEndian.Uint64(slc[j<<3:]))
-	}
 
 	fis, err := NewFrequencyItemsSketch[C](lgMaxMapSize, lgCurMapSize, hasher, serde)
 	if err != nil {
 		return nil, err
 	}
 	fis.streamWeight = 0 // update after
-	fis.offset = preArr[3]
+	fis.offset = int64(binary.LittleEndian.Uint64(slc[24:]))
 
 	preBytes := preLongs << 3
-	activeItems := extractActiveItems(preArr[1])
+	activeItems := extractActiveItems(int64(binary.LittleEndian.Uint64(slc[8:])))
 
-	// Get countArray
-	countArray := make([]int64, activeItems)
 	reqBytes := preBytes + activeItems*8 // count Arr only
 	if len(slc) < reqBytes {
 		return nil, fmt.Errorf("possible Corruption: Insufficient bytes in array: %d, %d", len(slc), reqBytes)
-	}
-	for j := 0; j < activeItems; j++ {
-		countArray[j] = int64(binary.LittleEndian.Uint64(slc[preBytes+j<<3:]))
 	}
 	// Get itemArray
 	itemsOffset := preBytes + (8 * activeItems)
@@ -174,14 +167,15 @@ func NewFrequencyItemsSketchFromSlice[C comparable](slc []byte, hasher common.It
 	if err != nil {
 		return nil, err
 	}
-	// update the sketch
+	// update the sketch, decoding counts in place
+	counts := slc[preBytes:itemsOffset]
 	for j := 0; j < activeItems; j++ {
-		err := fis.UpdateMany(itemArray[j], countArray[j])
-		if err != nil {
+		count := int64(binary.LittleEndian.Uint64(counts[j<<3:]))
+		if err := fis.UpdateMany(itemArray[j], count); err != nil {
 			return nil, err
 		}
 	}
-	fis.streamWeight = preArr[2] // override streamWeight due to updating
+	fis.streamWeight = int64(binary.LittleEndian.Uint64(slc[16:])) // override streamWeight due to updating
 	return fis, nil
 }
 

--- a/frequencies/items_sketch_test.go
+++ b/frequencies/items_sketch_test.go
@@ -25,8 +25,9 @@ import (
 	"strconv"
 	"testing"
 
-	"github.com/apache/datasketches-go/common"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/datasketches-go/common"
 )
 
 func TestEmpty(t *testing.T) {
@@ -667,6 +668,64 @@ func BenchmarkSlicesSortFuncRow(b *testing.B) {
 					}
 					return 0
 				})
+			}
+		})
+	}
+}
+
+var benchmarkItemsSketchFromSliceSink any
+
+func BenchmarkItemsSketchFromSlice(b *testing.B) {
+	benchmarkItemsSketchFromSlice(
+		b,
+		"int64",
+		common.ItemSketchLongHasher{},
+		common.ItemSketchLongSerDe{},
+		func(index int) int64 { return int64(index) },
+	)
+	benchmarkItemsSketchFromSlice(
+		b,
+		"string",
+		common.ItemSketchStringHasher{},
+		common.ItemSketchStringSerDe{},
+		func(index int) string { return "item-" + strconv.Itoa(index) },
+	)
+}
+
+func benchmarkItemsSketchFromSlice[C comparable](
+	b *testing.B,
+	itemType string,
+	hasher common.ItemSketchHasher[C],
+	serde common.ItemSketchSerde[C],
+	itemAt func(int) C,
+) {
+	for _, mapSize := range []int{64, 256, 1024} {
+		activeItems := mapSize * 3 / 4
+		b.Run(itemType+"/items="+strconv.Itoa(activeItems), func(b *testing.B) {
+			sketch, err := NewFrequencyItemsSketchWithMaxMapSize(mapSize, hasher, serde)
+			if err != nil {
+				b.Fatal(err)
+			}
+			for index := 0; index < activeItems; index++ {
+				if err := sketch.UpdateMany(itemAt(index), int64(index+1)); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			serialized, err := sketch.ToSlice()
+			if err != nil {
+				b.Fatal(err)
+			}
+			b.SetBytes(int64(len(serialized)))
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for iteration := 0; iteration < b.N; iteration++ {
+				restored, err := NewFrequencyItemsSketchFromSlice(serialized, hasher, serde)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkItemsSketchFromSliceSink = restored
 			}
 		})
 	}

--- a/frequencies/longs_sketch.go
+++ b/frequencies/longs_sketch.go
@@ -130,46 +130,36 @@ func NewLongsSketchFromSlice(slc []byte) (*LongsSketch, error) {
 	if empty {
 		return NewLongsSketch(lgMaxMapSize, _LG_MIN_MAP_SIZE)
 	}
-	// get full preamble
-	preArr := make([]int64, preLongs)
-	for i := 0; i < preLongs; i++ {
-		preArr[i] = int64(binary.LittleEndian.Uint64(slc[i<<3:]))
-	}
+
 	fls, err := NewLongsSketch(lgMaxMapSize, lgCurMapSize)
 	if err != nil {
 		return nil, err
 	}
 	fls.streamWeight = 0 //update after
-	fls.offset = preArr[3]
+	fls.offset = int64(binary.LittleEndian.Uint64(slc[24:]))
 
 	preBytes := preLongs << 3
-	activeItems := extractActiveItems(preArr[1])
+	activeItems := extractActiveItems(int64(binary.LittleEndian.Uint64(slc[8:])))
 
-	// Get countArray
-	countArray := make([]int64, activeItems)
 	reqBytes := preBytes + 2*activeItems*8 //count Arr + Items Arr
 	if len(slc) < reqBytes {
 		return nil, fmt.Errorf("possible Corruption: Insufficient bytes in array: %d, %d", len(slc), reqBytes)
 	}
+
+	// UpdateMany the sketch, decoding counts and items straight out of slc.
+	// Counts occupy the activeItems longs starting at preBytes; items follow them.
+	itemsOffset := preBytes + (activeItems << 3)
+	counts := slc[preBytes:itemsOffset]
+	items := slc[itemsOffset:reqBytes]
 	for i := 0; i < activeItems; i++ {
-		countArray[i] = int64(binary.LittleEndian.Uint64(slc[preBytes+(i<<3):]))
+		count := int64(binary.LittleEndian.Uint64(counts[i<<3:]))
+		item := int64(binary.LittleEndian.Uint64(items[i<<3:]))
+		if err := fls.UpdateMany(item, count); err != nil {
+			return nil, err
+		}
 	}
 
-	// Get itemArray
-	itemsOffset := preBytes + (8 * activeItems)
-	itemArray := make([]int64, activeItems)
-	for i := 0; i < activeItems; i++ {
-		itemArray[i] = int64(binary.LittleEndian.Uint64(slc[itemsOffset+(i<<3):]))
-	}
-
-	// UpdateMany the sketch
-	for i := 0; i < activeItems && err == nil; i++ {
-		err = fls.UpdateMany(itemArray[i], countArray[i])
-	}
-	if err != nil {
-		return nil, err
-	}
-	fls.streamWeight = preArr[2] //override streamWeight due to updating
+	fls.streamWeight = int64(binary.LittleEndian.Uint64(slc[16:])) //override streamWeight due to updating
 	return fls, nil
 }
 

--- a/frequencies/longs_sketch_test.go
+++ b/frequencies/longs_sketch_test.go
@@ -20,11 +20,13 @@ package frequencies
 import (
 	"encoding/binary"
 	"fmt"
+	"strconv"
 	"strings"
 	"testing"
 
-	"github.com/apache/datasketches-go/internal"
 	"github.com/stretchr/testify/assert"
+
+	"github.com/apache/datasketches-go/internal"
 )
 
 func TestFrequentItemsStringSerial(t *testing.T) {
@@ -642,5 +644,37 @@ func BenchmarkLongSketch(b *testing.B) {
 	assert.NoError(b, err)
 	for i := 0; i < b.N; i++ {
 		sketch.Update(int64(i))
+	}
+}
+
+var benchmarkLongsSketchFromSliceSink *LongsSketch
+
+func BenchmarkLongsSketchFromSlice(b *testing.B) {
+	for _, mapSize := range []int{64, 256, 1024} {
+		activeItems := mapSize * 3 / 4
+		b.Run("items="+strconv.Itoa(activeItems), func(b *testing.B) {
+			sketch, err := NewLongsSketchWithMaxMapSize(mapSize)
+			if err != nil {
+				b.Fatal(err)
+			}
+			for index := 0; index < activeItems; index++ {
+				if err := sketch.UpdateMany(int64(index), int64(index+1)); err != nil {
+					b.Fatal(err)
+				}
+			}
+
+			serialized := sketch.ToSlice()
+			b.SetBytes(int64(len(serialized)))
+			b.ReportAllocs()
+			b.ResetTimer()
+
+			for iteration := 0; iteration < b.N; iteration++ {
+				restored, err := NewLongsSketchFromSlice(serialized)
+				if err != nil {
+					b.Fatal(err)
+				}
+				benchmarkLongsSketchFromSliceSink = restored
+			}
+		})
 	}
 }


### PR DESCRIPTION
In deserialization, current temp allocation happens. we can reduce that. 
And we can reduce two loops into one loop.

## ItemsSketch

main:
```
goos: darwin
goarch: arm64
pkg: github.com/apache/datasketches-go/frequencies
cpu: Apple M4 Pro
BenchmarkItemsSketchFromSlice
BenchmarkItemsSketchFromSlice/int64/items=48
BenchmarkItemsSketchFromSlice/int64/items=48-12         	 1298882	       908.8 ns/op	 880.28 MB/s	    2096 B/op	       7 allocs/op
BenchmarkItemsSketchFromSlice/int64/items=192
BenchmarkItemsSketchFromSlice/int64/items=192-12        	  327068	      3683 ns/op	 842.75 MB/s	    7856 B/op	       7 allocs/op
BenchmarkItemsSketchFromSlice/int64/items=768
BenchmarkItemsSketchFromSlice/int64/items=768-12        	   78704	     15302 ns/op	 805.14 MB/s	   30896 B/op	       7 allocs/op
BenchmarkItemsSketchFromSlice/string/items=48
BenchmarkItemsSketchFromSlice/string/items=48-12        	  770403	      1510 ns/op	 618.69 MB/s	    3632 B/op	      55 allocs/op
BenchmarkItemsSketchFromSlice/string/items=192
BenchmarkItemsSketchFromSlice/string/items=192-12       	  201334	      6039 ns/op	 622.92 MB/s	   13872 B/op	     199 allocs/op
BenchmarkItemsSketchFromSlice/string/items=768
BenchmarkItemsSketchFromSlice/string/items=768-12       	   48657	     24591 ns/op	 621.44 MB/s	   54704 B/op	     775 allocs/op
PASS
```

PR:
```
goos: darwin
goarch: arm64
pkg: github.com/apache/datasketches-go/frequencies
cpu: Apple M4 Pro
BenchmarkItemsSketchFromSlice
BenchmarkItemsSketchFromSlice/int64/items=48
BenchmarkItemsSketchFromSlice/int64/items=48-12         	 1419704	       845.1 ns/op	 946.62 MB/s	    1712 B/op	       6 allocs/op
BenchmarkItemsSketchFromSlice/int64/items=192
BenchmarkItemsSketchFromSlice/int64/items=192-12        	  342088	      3459 ns/op	 897.38 MB/s	    6320 B/op	       6 allocs/op
BenchmarkItemsSketchFromSlice/int64/items=768
BenchmarkItemsSketchFromSlice/int64/items=768-12        	   82773	     14514 ns/op	 848.81 MB/s	   24752 B/op	       6 allocs/op
BenchmarkItemsSketchFromSlice/string/items=48
BenchmarkItemsSketchFromSlice/string/items=48-12        	  803619	      1447 ns/op	 645.27 MB/s	    3248 B/op	      54 allocs/op
BenchmarkItemsSketchFromSlice/string/items=192
BenchmarkItemsSketchFromSlice/string/items=192-12       	  207325	      5827 ns/op	 645.62 MB/s	   12336 B/op	     198 allocs/op
BenchmarkItemsSketchFromSlice/string/items=768
BenchmarkItemsSketchFromSlice/string/items=768-12       	   50332	     23517 ns/op	 649.84 MB/s	   48560 B/op	     774 allocs/op
PASS
```



## LongsSketch

main:
```
goos: darwin
goarch: arm64
pkg: github.com/apache/datasketches-go/frequencies
cpu: Apple M4 Pro
BenchmarkLongsSketchFromSlice
BenchmarkLongsSketchFromSlice/items=48
BenchmarkLongsSketchFromSlice/items=48-12         	 2753096	       429.0 ns/op	1864.97 MB/s	    2064 B/op	       7 allocs/op
BenchmarkLongsSketchFromSlice/items=192
BenchmarkLongsSketchFromSlice/items=192-12        	  774289	      1511 ns/op	2053.71 MB/s	    7824 B/op	       7 allocs/op
BenchmarkLongsSketchFromSlice/items=768
BenchmarkLongsSketchFromSlice/items=768-12        	  208054	      5727 ns/op	2151.25 MB/s	   30864 B/op	       7 allocs/op
PASS
```


PR:
```
goos: darwin
goarch: arm64
pkg: github.com/apache/datasketches-go/frequencies
cpu: Apple M4 Pro
BenchmarkLongsSketchFromSlice
BenchmarkLongsSketchFromSlice/items=48
BenchmarkLongsSketchFromSlice/items=48-12         	 3277532	       352.7 ns/op	2268.47 MB/s	    1296 B/op	       5 allocs/op
BenchmarkLongsSketchFromSlice/items=192
BenchmarkLongsSketchFromSlice/items=192-12        	  978699	      1265 ns/op	2453.94 MB/s	    4752 B/op	       5 allocs/op
BenchmarkLongsSketchFromSlice/items=768
BenchmarkLongsSketchFromSlice/items=768-12        	  247640	      4888 ns/op	2520.38 MB/s	   18576 B/op	       5 allocs/op
PASS
```
